### PR TITLE
add import of balder version

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,10 +14,12 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../src'))
 
+from balder import __version__
 
 # -- Project information -----------------------------------------------------
 
 project = 'balder'
+version = __version__
 copyright = '2021, Max Stahlschmidt'
 author = 'Max Stahlschmidt'
 


### PR DESCRIPTION
The readthedocs build for epub fails because `version` is missing in `doc/conf.py`.