### PR TITLE
add missing path in `tutorial_guide/00_intro.rst`

### DIFF
--- a/doc/source/tutorial_guide/00_intro.rst
+++ b/doc/source/tutorial_guide/00_intro.rst
@@ -33,7 +33,7 @@ After you have installed git, you can checkout the repository with the command:
 
 .. code-block::
 
-    >>> git checkout <TODO insert here>
+    >>> git clone https://github.com/balder-dev/balderexample-loginserver.git
 
 This command will download the latest environment of the loginserver.
 


### PR DESCRIPTION
The clone path for the loginserver example was missing