### PR TITLE
refactor and use no relative imports anymore

### DIFF
--- a/src/_balder/balder_plugin.py
+++ b/src/_balder/balder_plugin.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Type, Tuple, List
 
 if TYPE_CHECKING:
-    from .executor.executor_tree import ExecutorTree
-    from .balder_session import BalderSession
-    from .setup import Setup
-    from .scenario import Scenario
+    from _balder.executor.executor_tree import ExecutorTree
+    from _balder.balder_session import BalderSession
+    from _balder.setup import Setup
+    from _balder.scenario import Scenario
     import argparse
 
 import pathlib

--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 from typing import Union, List, Tuple, Dict, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .setup import Setup
-    from .device import Device
-    from .scenario import Scenario
-    from .connection import Connection
+    from _balder.setup import Setup
+    from _balder.device import Device
+    from _balder.scenario import Scenario
+    from _balder.connection import Connection
 
 import os
 import sys
@@ -13,13 +13,13 @@ import balder
 import inspect
 import pathlib
 import argparse
-from .balder_plugin import BalderPlugin
-from .plugin_manager import PluginManager
-from .executor.executor_tree import ExecutorTree
-from .collector import Collector
-from .solver import Solver
-from .exceptions import DuplicateBalderSettingError
-from .balder_settings import BalderSettings
+from _balder.balder_plugin import BalderPlugin
+from _balder.plugin_manager import PluginManager
+from _balder.executor.executor_tree import ExecutorTree
+from _balder.collector import Collector
+from _balder.solver import Solver
+from _balder.exceptions import DuplicateBalderSettingError
+from _balder.balder_settings import BalderSettings
 
 
 class BalderSession:

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -289,7 +289,7 @@ class Collector:
         """
         This method resolves all raw fixtures and sets the resolved attribute `ExecutorTree.fixtures`
         """
-        from .executor.executor_tree import ExecutorTree
+        from _balder.executor.executor_tree import ExecutorTree
         resolved_dict = {}
         for cur_level, cur_module_fixture_dict in ExecutorTree.raw_fixtures.items():
             resolved_dict[cur_level] = {}

--- a/src/_balder/controllers/__init__.py
+++ b/src/_balder/controllers/__init__.py
@@ -1,12 +1,12 @@
-from .controller import Controller
+from _balder.controllers.controller import Controller
 
-from .base_device_controller import BaseDeviceController
-from .device_controller import DeviceController
+from _balder.controllers.base_device_controller import BaseDeviceController
+from _balder.controllers.device_controller import DeviceController
 
-from .vdevice_controller import VDeviceController
+from _balder.controllers.vdevice_controller import VDeviceController
 
-from .normal_scenario_setup_controller import NormalScenarioSetupController
-from .scenario_controller import ScenarioController
-from .setup_controller import SetupController
+from _balder.controllers.normal_scenario_setup_controller import NormalScenarioSetupController
+from _balder.controllers.scenario_controller import ScenarioController
+from _balder.controllers.setup_controller import SetupController
 
-from .feature_controller import FeatureController
+from _balder.controllers.feature_controller import FeatureController

--- a/src/_balder/controllers/base_device_controller.py
+++ b/src/_balder/controllers/base_device_controller.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from _balder.feature import Feature
 
 import inspect
-from .controller import Controller
+from _balder.controllers.controller import Controller
 
 logger = logging.getLogger(__file__)
 

--- a/src/_balder/controllers/device_controller.py
+++ b/src/_balder/controllers/device_controller.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 import inspect
 from _balder.device import Device
-from .base_device_controller import BaseDeviceController
+from _balder.controllers.base_device_controller import BaseDeviceController
 from _balder.exceptions import DeviceScopeError, DeviceResolvingException
 
 logger = logging.getLogger(__file__)

--- a/src/_balder/controllers/feature_controller.py
+++ b/src/_balder/controllers/feature_controller.py
@@ -154,7 +154,7 @@ class FeatureController(Controller):
         :return: the method variation callable for the given data (or none, if the method does not exist in this object
                  or in a parent class of it)
         """
-        from balder import Connection
+        from _balder.connection import Connection
 
         all_vdevice_method_variations = self.get_method_based_for_vdevice()
 

--- a/src/_balder/controllers/normal_scenario_setup_controller.py
+++ b/src/_balder/controllers/normal_scenario_setup_controller.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 import inspect
 from _balder.setup import Setup
 from _balder.scenario import Scenario
-from .controller import Controller
-from .device_controller import DeviceController
+from _balder.controllers.controller import Controller
+from _balder.controllers.device_controller import DeviceController
 from _balder.exceptions import MultiInheritanceError, DeviceOverwritingError
 
 

--- a/src/_balder/controllers/scenario_controller.py
+++ b/src/_balder/controllers/scenario_controller.py
@@ -7,7 +7,7 @@ from typing import Type, Dict, List, TYPE_CHECKING
 if TYPE_CHECKING:
     from _balder.scenario import Scenario
 
-from .normal_scenario_setup_controller import NormalScenarioSetupController
+from _balder.controllers.normal_scenario_setup_controller import NormalScenarioSetupController
 
 
 logger = logging.getLogger(__file__)

--- a/src/_balder/controllers/setup_controller.py
+++ b/src/_balder/controllers/setup_controller.py
@@ -6,7 +6,7 @@ from typing import Type, Dict, TYPE_CHECKING
 if TYPE_CHECKING:
     from _balder.setup import Setup
 
-from .normal_scenario_setup_controller import NormalScenarioSetupController
+from _balder.controllers.normal_scenario_setup_controller import NormalScenarioSetupController
 
 logger = logging.getLogger(__file__)
 

--- a/src/_balder/controllers/vdevice_controller.py
+++ b/src/_balder/controllers/vdevice_controller.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from _balder.feature import Feature
 
 import inspect
-from .base_device_controller import BaseDeviceController
+from _balder.controllers.base_device_controller import BaseDeviceController
 from _balder.exceptions import DeviceScopeError
 
 

--- a/src/_balder/executor/basic_executor.py
+++ b/src/_balder/executor/basic_executor.py
@@ -3,7 +3,7 @@ from _balder.testresult import FixturePartResult, ResultState
 from typing import List, Dict, Union, Type, TYPE_CHECKING
 import types
 from _balder.previous_executor_mark import PreviousExecutorMark
-from ..testresult import TestcaseResult
+from _balder.testresult import TestcaseResult
 
 if TYPE_CHECKING:
     from _balder.setup import Setup

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -10,9 +10,9 @@ if TYPE_CHECKING:
 
 import sys
 import traceback
-from .setup_executor import SetupExecutor
-from .basic_executor import BasicExecutor
-from ..fixture_manager import FixtureManager
+from _balder.executor.setup_executor import SetupExecutor
+from _balder.executor.basic_executor import BasicExecutor
+from _balder.fixture_manager import FixtureManager
 from _balder.testresult import ResultState, BranchBodyResult
 from _balder.previous_executor_mark import PreviousExecutorMark
 

--- a/src/_balder/feature.py
+++ b/src/_balder/feature.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 from _balder.controllers import FeatureController
 
-from .exceptions import UnclearMethodVariationError
+from _balder.exceptions import UnclearMethodVariationError
 
 
 class Feature:

--- a/src/_balder/fixture_manager.py
+++ b/src/_balder/fixture_manager.py
@@ -27,7 +27,7 @@ class FixtureManager:
     EXECUTION_LEVEL_ORDER = ['session', 'setup', 'scenario', 'variation', 'testcase']
 
     def __init__(self, executor_tree):
-        from .executor.executor_tree import ExecutorTree
+        from _balder.executor.executor_tree import ExecutorTree
         self._executor_tree: ExecutorTree = executor_tree
 
         # contains all active fixtures with their namespace, their func_type, their callable, the generator object
@@ -45,11 +45,11 @@ class FixtureManager:
 
     @property
     def RESOLVE_TYPE_LEVEL(self):
-        from .executor.executor_tree import ExecutorTree
-        from .executor.setup_executor import SetupExecutor
-        from .executor.scenario_executor import ScenarioExecutor
-        from .executor.variation_executor import VariationExecutor
-        from .executor.testcase_executor import TestcaseExecutor
+        from _balder.executor.executor_tree import ExecutorTree
+        from _balder.executor.setup_executor import SetupExecutor
+        from _balder.executor.scenario_executor import ScenarioExecutor
+        from _balder.executor.variation_executor import VariationExecutor
+        from _balder.executor.testcase_executor import TestcaseExecutor
 
         return {
             ExecutorTree: 'session',
@@ -64,7 +64,7 @@ class FixtureManager:
         """
         returns a list with the definition scope objects in the priority order (ExecutorTree stands for global fixtures)
         """
-        from .executor.executor_tree import ExecutorTree
+        from _balder.executor.executor_tree import ExecutorTree
         return [ExecutorTree, Setup, Scenario]
 
     @property
@@ -107,11 +107,11 @@ class FixtureManager:
 
         :return: the method returns a dictionary with the attribute name as key and the return value as value
         """
-        from .executor.executor_tree import ExecutorTree
-        from .executor.setup_executor import SetupExecutor
-        from .executor.scenario_executor import ScenarioExecutor
-        from .executor.variation_executor import VariationExecutor
-        from .executor.testcase_executor import TestcaseExecutor
+        from _balder.executor.executor_tree import ExecutorTree
+        from _balder.executor.setup_executor import SetupExecutor
+        from _balder.executor.scenario_executor import ScenarioExecutor
+        from _balder.executor.variation_executor import VariationExecutor
+        from _balder.executor.testcase_executor import TestcaseExecutor
 
         arguments = inspect.getfullargspec(callable_func).args
         result_dict = {}

--- a/src/_balder/plugin_manager.py
+++ b/src/_balder/plugin_manager.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import argparse
 from typing import TYPE_CHECKING, List, Type, Tuple
-from .balder_plugin import BalderPlugin
+from _balder.balder_plugin import BalderPlugin
 
 if TYPE_CHECKING:
-    from .balder_session import BalderSession
-    from .executor.executor_tree import ExecutorTree
-    from .scenario import Scenario
-    from .setup import Setup
+    from _balder.balder_session import BalderSession
+    from _balder.executor.executor_tree import ExecutorTree
+    from _balder.scenario import Scenario
+    from _balder.setup import Setup
 
 import pathlib
-from .exceptions import UnexpectedPluginMethodReturnValue
+from _balder.exceptions import UnexpectedPluginMethodReturnValue
 
 
 class PluginManager:

--- a/src/_balder/solver.py
+++ b/src/_balder/solver.py
@@ -10,11 +10,11 @@ if TYPE_CHECKING:
     from _balder.plugin_manager import PluginManager
 
 import itertools
-from .executor.executor_tree import ExecutorTree
-from .executor.setup_executor import SetupExecutor
-from .executor.scenario_executor import ScenarioExecutor
-from .executor.testcase_executor import TestcaseExecutor
-from .executor.variation_executor import VariationExecutor
+from _balder.executor.executor_tree import ExecutorTree
+from _balder.executor.setup_executor import SetupExecutor
+from _balder.executor.scenario_executor import ScenarioExecutor
+from _balder.executor.testcase_executor import TestcaseExecutor
+from _balder.executor.variation_executor import VariationExecutor
 from _balder.previous_executor_mark import PreviousExecutorMark
 from _balder.controllers import ScenarioController, SetupController
 

--- a/src/_balder/testresult.py
+++ b/src/_balder/testresult.py
@@ -89,7 +89,7 @@ class BranchBodyResult(_Result):
     """
 
     def __init__(self, executor: BasicExecutor):
-        from .executor.testcase_executor import TestcaseExecutor
+        from _balder.executor.testcase_executor import TestcaseExecutor
 
         if isinstance(executor, TestcaseExecutor):
             raise TypeError("testcase executors are not allowed to use in `BranchBodyResult`")

--- a/src/_balder/vdevice.py
+++ b/src/_balder/vdevice.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .device import Device
+from _balder.device import Device
 
 
 class VDevice(Device):


### PR DESCRIPTION
No relative imports should be used within the project. This PR exchanges all relative imports with absolute imports. In addition internally only imports to the protected `_balder` environment are done.