### PR TITLE
fix pylint message `bare-except`

### DIFF
--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -160,12 +160,12 @@ class ExecutorTree(BasicExecutor):
                             cur_setup_executor.set_result_for_whole_branch(ResultState.COVERED_BY)
                         else:
                             cur_setup_executor.set_result_for_whole_branch(ResultState.NOT_RUN)
-                except:
+                except Exception:
                     # we can catch everything, because error is already documented
                     traceback.print_exception(*sys.exc_info())
                 if self.fixture_manager.is_allowed_to_leave(self):
                     self.fixture_manager.leave(self)
-            except:
+            except Exception:
                 # we can catch everything, because error is already documented
                 traceback.print_exception(*sys.exc_info())
         else:

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -215,11 +215,11 @@ class ScenarioExecutor(BasicExecutor):
                         cur_variation_executor.set_result_for_whole_branch(ResultState.COVERED_BY)
                     else:
                         cur_variation_executor.set_result_for_whole_branch(ResultState.NOT_RUN)
-            except:
+            except Exception:
                 # we can catch everything, because error is already documented
                 traceback.print_exception(*sys.exc_info())
             if self.fixture_manager.is_allowed_to_leave(self):
                 self.fixture_manager.leave(self)
-        except:
+        except Exception:
             # we can catch everything, because error is already documented
             traceback.print_exception(*sys.exc_info())

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -127,11 +127,11 @@ class SetupExecutor(BasicExecutor):
                         cur_scenario_executor.set_result_for_whole_branch(ResultState.COVERED_BY)
                     else:
                         cur_scenario_executor.set_result_for_whole_branch(ResultState.NOT_RUN)
-            except:
+            except Exception:
                 # we can catch everything, because error is already documented
                 traceback.print_exception(*sys.exc_info())
             if self.fixture_manager.is_allowed_to_leave(self):
                 self.fixture_manager.leave(self)
-        except:
+        except Exception:
             # we can catch everything, because error is already documented
             traceback.print_exception(*sys.exc_info())

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -153,17 +153,17 @@ class TestcaseExecutor(BasicExecutor):
                                          f"`{self.base_testcase_callable.__name__}`")
 
                     self.body_result.set_result(ResultState.SUCCESS)
-                except:
+                except Exception:
                     traceback.print_exception(*sys.exc_info())
                     self.body_result.set_result(ResultState.FAILURE)
                 finally:
                     self.execution_time_sec = time.perf_counter() - start_time
-            except:
+            except Exception:
                 # we can catch everything, because error is already documented
                 traceback.print_exception(*sys.exc_info())
             if self.fixture_manager.is_allowed_to_leave(self):
                 self.fixture_manager.leave(self)
             print(f"[{self.body_result.get_result_as_char()}]")
-        except:
+        except Exception:
             # we can catch everything, because error is already documented
             traceback.print_exception(*sys.exc_info())

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -815,12 +815,12 @@ class VariationExecutor(BasicExecutor):
                         cur_testcase_executor.set_result_for_whole_branch(ResultState.COVERED_BY)
                     else:
                         cur_testcase_executor.set_result_for_whole_branch(ResultState.NOT_RUN)
-            except:
+            except Exception:
                 # we can catch everything, because error is already documented
                 traceback.print_exception(*sys.exc_info())
             if self.fixture_manager.is_allowed_to_leave(self):
                 self.fixture_manager.leave(self)
-        except:
+        except Exception:
             # we can catch everything, because error is already documented
             traceback.print_exception(*sys.exc_info())
         finally:


### PR DESCRIPTION
The executor objects should catch all exceptions, because every exception could be thrown in a test. For this we need the bare exception, but we can use the main `Exception` object as type to fix the pylint message `bare-except`.