### PR TITLE
use python version v3.9 or higher for pylint too

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,7 +8,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Balder is not supported for python version lower than 3.9. Unfortunatelly, I used the wrong python version v3.8 for the pylint workflow. Of course, we should use pylint with the supported versions too.