### PR TITLE
refactor(*): add pylint message control disable message for `unused-argument`

### DIFF
--- a/src/_balder/decorator_connect.py
+++ b/src/_balder/decorator_connect.py
@@ -61,7 +61,7 @@ def connect(with_device: Union[Type[Device], str], over_connection: Union[Type[C
         object and if the `dest_node_name` is None, it will also set this value to None. This secure that the
         collector will create a unique auto node for it.
         """
-        def __new__(cls, *args, **kwargs):
+        def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
 
             decorated_cls = args[0]
             nonlocal with_device

--- a/src/_balder/decorator_for_vdevice.py
+++ b/src/_balder/decorator_for_vdevice.py
@@ -78,7 +78,7 @@ def for_vdevice(
                 Collector._possible_method_variations[func] = []
             Collector._possible_method_variations[func].append((vdevice, with_connections))
 
-        def __new__(cls, *args, **kwargs):
+        def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
             nonlocal vdevice
 
             func = args[0]

--- a/src/_balder/decorator_insert_into_tree.py
+++ b/src/_balder/decorator_insert_into_tree.py
@@ -35,7 +35,7 @@ def insert_into_tree(parents: List[Union[Type[Connection], Tuple[Type[Connection
 
     class MyDecorator:
         """decorator class for `@insert_into_tree` decorator"""
-        def __new__(cls, *args, **kwargs):
+        def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
 
             nonlocal parents
 

--- a/src/_balder/solver.py
+++ b/src/_balder/solver.py
@@ -136,7 +136,7 @@ class Solver:
                     mapping.append((cur_setup, cur_scenario, device_mapping))
         return mapping
 
-    def resolve(self, plugin_manager: PluginManager) -> None:
+    def resolve(self, plugin_manager: PluginManager) -> None:  # pylint: disable=unused-argument
         """
         This method carries out the entire resolve process and saves the end result in the object property
         `self._mapping`.
@@ -147,7 +147,7 @@ class Solver:
         self._mapping = initial_mapping
         self._resolving_was_executed = True
 
-    def get_executor_tree(self, plugin_manager: PluginManager) -> ExecutorTree:
+    def get_executor_tree(self, plugin_manager: PluginManager) -> ExecutorTree:  # pylint: disable=unused-argument
         """
         This method builds the ExecutorTree from the resolved data and returns it
 
@@ -155,7 +155,6 @@ class Solver:
         """
 
         executor_tree = ExecutorTree()
-
 
         # create all setup executor
 


### PR DESCRIPTION
This PR disables the pylint message `unused-argument` for some specific lines.