### PR TITLE
rework fixture collection

### DIFF
--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -282,7 +282,7 @@ class BalderSession:
         This method resolves all classes and executes different checks, that can be done before the test session starts.
         """
         self.solver = Solver(setups=self.all_collected_setups, scenarios=self.all_collected_scenarios,
-                             connections=self.all_collected_connections)
+                             connections=self.all_collected_connections, raw_fixtures=self.collector.raw_fixtures)
         self.solver.resolve(plugin_manager=self.plugin_manager)
 
     def create_executor_tree(self):

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -9,14 +9,13 @@ import inspect
 import pathlib
 import functools
 import importlib.util
-from _balder.utils import inspect_method, get_class_that_defines_method
+from _balder.utils import get_class_that_defines_method
 from _balder.setup import Setup
 from _balder.device import Device
 from _balder.feature import Feature
 from _balder.vdevice import VDevice
 from _balder.scenario import Scenario
 from _balder.connection import Connection
-from _balder.executor.executor_tree import ExecutorTree
 from _balder.controllers import ScenarioController, SetupController, DeviceController, VDeviceController, \
     FeatureController, NormalScenarioSetupController
 from _balder.exceptions import VDeviceResolvingError, IllegalVDeviceMappingError, DuplicateForVDeviceError, \
@@ -302,22 +301,6 @@ class Collector:
         for cur_scenario_or_setup in items:
             cur_scenario_or_setup_controller = NormalScenarioSetupController.get_for(cur_scenario_or_setup)
             cur_scenario_or_setup_controller.validate_inheritance()
-
-    @staticmethod
-    def resolve_raw_fixtures():
-        """
-        This method resolves all raw fixtures and sets the resolved attribute `ExecutorTree.fixtures`
-        """
-        resolved_dict = {}
-        for cur_level, cur_module_fixture_dict in Collector.raw_fixtures.items():
-            resolved_dict[cur_level] = {}
-            for cur_fn in cur_module_fixture_dict:
-                cls, func_type = inspect_method(cur_fn)
-                # mechanism also works for balderglob fixtures (`func_type` is 'function' and `cls` is None)
-                if cls not in resolved_dict[cur_level].keys():
-                    resolved_dict[cur_level][cls] = []
-                resolved_dict[cur_level][cls].append((func_type, cur_fn))
-        ExecutorTree.fixtures = resolved_dict
 
     def set_run_skip_ignore_of_test_methods_in_scenarios(self):
         """
@@ -977,7 +960,6 @@ class Collector:
         # do some further stuff after everything was read
         self.set_original_device_features_for(self._all_scenarios)
         self.set_original_device_features_for(self._all_setups)
-        Collector.resolve_raw_fixtures()
         Collector.set_original_device_features_for_all_vdevices_of(all_scenario_features)
         Collector.set_original_device_features_for_all_vdevices_of(all_setup_features)
         self.exchange_device_connection_device_strings()

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -34,6 +34,8 @@ class Collector:
     The Collector class manages the loading and importing of all relevant balder objects. It does not resolve something,
     but secures that all relevant data is being collected.
     """
+    # metadata object that contains all raw fixtures (classes that were not be resolved yet)
+    raw_fixtures = {}
 
     # this static attribute will be managed by the decorator `@for_vdevice(..)`. It holds all functions/methods that
     # were decorated with `@for_vdevice(..)` (without checking their correctness). The collector will check them later
@@ -307,7 +309,7 @@ class Collector:
         This method resolves all raw fixtures and sets the resolved attribute `ExecutorTree.fixtures`
         """
         resolved_dict = {}
-        for cur_level, cur_module_fixture_dict in ExecutorTree.raw_fixtures.items():
+        for cur_level, cur_module_fixture_dict in Collector.raw_fixtures.items():
             resolved_dict[cur_level] = {}
             for cur_fn in cur_module_fixture_dict:
                 cls, func_type = inspect_method(cur_fn)

--- a/src/_balder/decorator_fixture.py
+++ b/src/_balder/decorator_fixture.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Literal
 
 import functools
-from _balder.executor.executor_tree import ExecutorTree
+from _balder.collector import Collector
 from _balder.fixture_manager import FixtureManager
 
 
@@ -20,11 +20,9 @@ def fixture(level: Literal['session', 'setup', 'scenario', 'variation', 'testcas
     def decorator_fixture(func):
         # always add the fixture to FixtureManager.raw_fixtures - class determination will be done later by
         # :meth:`Collector`
-        if not hasattr(ExecutorTree, 'raw_fixtures'):
-            ExecutorTree.raw_fixtures = {}
-        if level not in ExecutorTree.raw_fixtures.keys():
-            ExecutorTree.raw_fixtures[level] = []
-        ExecutorTree.raw_fixtures[level].append(func)
+        if level not in Collector.raw_fixtures.keys():
+            Collector.raw_fixtures[level] = []
+        Collector.raw_fixtures[level].append(func)
 
         @functools.wraps(func)
         def wrapper_fixture(*args, **kwargs):

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -21,13 +21,10 @@ class ExecutorTree(BasicExecutor):
     This class is the root object of the executor tree structure
     """
 
-    # metadata object that contains all fixtures (balderglob, Setup and Scenario classes)
-    fixtures = {}
-
-    def __init__(self):
+    def __init__(self, fixture_manager: FixtureManager):
         super().__init__()
         self._setup_executors: List[SetupExecutor] = []
-        self._fixture_manager = FixtureManager(executor_tree=self)
+        self._fixture_manager = fixture_manager
 
         # contains the result object for the BODY part of this branch (will be overwritten in :class:`TestcaseExecutor`)
         self.body_result = BranchBodyResult(self)

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -21,9 +21,6 @@ class ExecutorTree(BasicExecutor):
     This class is the root object of the executor tree structure
     """
 
-    # metadata object that contains all raw fixtures (classes that were not be resolved yet)
-    raw_fixtures = {}
-
     # metadata object that contains all fixtures (balderglob, Setup and Scenario classes)
     fixtures = {}
 

--- a/src/_balder/fixture_manager.py
+++ b/src/_balder/fixture_manager.py
@@ -16,6 +16,7 @@ from _balder.exceptions import LostInExecutorTreeException, FixtureReferenceErro
     UnclearUniqueClassReference
 
 if TYPE_CHECKING:
+    from _balder.utils import METHOD_TYPE
     from _balder.executor.executor_tree import ExecutorTree
 
 
@@ -26,8 +27,12 @@ class FixtureManager:
     #: the ordering for the execution levels
     EXECUTION_LEVEL_ORDER = ['session', 'setup', 'scenario', 'variation', 'testcase']
 
-    def __init__(self, executor_tree):
-        self._executor_tree: ExecutorTree = executor_tree
+    def __init__(self, fixtures: Dict[str, Dict[Union[type, None], List[Tuple[METHOD_TYPE, Callable]]]]):
+
+        # The first key is the fixture level, the second key is the namespace in which the fixture is defined (for
+        # example the scenario class), which describes the definition-scope. As value a list with tuples is returned.
+        #  The first element is the type of the method/function and the second is the callable itself.
+        self.fixtures: Dict[str, Dict[Union[type, None], List[Tuple[METHOD_TYPE, Callable]]]] = fixtures
 
         # contains all active fixtures with their namespace, their func_type, their callable, the generator object
         # (otherwise an empty generator, if the fixture is not a generator) and the result according to the fixture's
@@ -189,13 +194,12 @@ class FixtureManager:
 
         :param cur_execution_level: the current execution level that is currently active
         """
-        from _balder.executor.executor_tree import ExecutorTree
         # this method is only interested in fixtures with execution level SESSION!
 
         if isinstance(fixture_callable_namespace, Scenario) and cur_execution_level == "session":
             all_setup_scoped_fixtures = []
 
-            for cur_namespace_type, fixtures in ExecutorTree.fixtures.get('session', {}).items():
+            for cur_namespace_type, fixtures in self.fixtures.get('session', {}).items():
                 if cur_namespace_type is not None and issubclass(cur_namespace_type, Setup):
                     all_setup_scoped_fixtures += [cur_fixt.__name__ for _, cur_fixt in fixtures]
             for cur_arg in arguments:
@@ -426,7 +430,7 @@ class FixtureManager:
         # current relevant EXECUTION LEVEL - all other levels are not relevant for this call
         cur_execution_level = self.resolve_type_level[branch.__class__]
         # get all fixtures of the current relevant level
-        fixtures_of_exec_level = ExecutorTree.fixtures.get(cur_execution_level, {})
+        fixtures_of_exec_level = self.fixtures.get(cur_execution_level, {})
 
         all_fixtures = {}
         # get all relevant fixtures of `balderglob.py` (None is key for balderglob fixtures)

--- a/src/_balder/utils.py
+++ b/src/_balder/utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
-from typing import List, Type, Tuple, Union
+from typing import List, Type, Tuple, Union, Literal
 
 import sys
 import inspect
 from _balder.scenario import Scenario
 from _balder.exceptions import InheritanceError
+
+METHOD_TYPE = Literal["function", "classmethod", "staticmethod", "instancemethod"]
 
 
 def get_scenario_inheritance_list_of(scenario: Type[Scenario]) -> List[Type[Scenario]]:
@@ -43,7 +45,7 @@ def get_class_that_defines_method(meth):
     return None  # not required since None would have been implicitly returned anyway
 
 
-def inspect_method(func) -> Tuple[Union[type, None], str]:
+def inspect_method(func) -> Tuple[Union[type, None], METHOD_TYPE]:
     """
     This helper function returns the related class and the type of the method (`staticmethod`, `classmethod`,
     `instancemethod` or `function`) as tuple.
@@ -69,7 +71,7 @@ def inspect_method(func) -> Tuple[Union[type, None], str]:
         return cls, 'classmethod'
 
     if type(fn_type) == staticmethod:
-        return cls, 'staticmethod',
+        return cls, 'staticmethod'
 
     if fn_type.__class__.__name__ == 'function':
         return cls, 'instancemethod'


### PR DESCRIPTION
This PR reworks the fixture resolving, which is now moved to `Solver`. It also removes the dependency of fixture_manager from ExecutorTree and uses resolved fixture as constructor argument from now on.