### PR TITLE
integrate different types of exit codes

### DIFF
--- a/src/_balder/console/balder.py
+++ b/src/_balder/console/balder.py
@@ -35,7 +35,13 @@ def _console_balder_debug(cmd_args: Optional[List[str]] = None, working_dir: Uni
         elif balder_session.executor_tree.executor_result == ResultState.SUCCESS:
             exit(ExitCode.SUCCESS.value)
         elif balder_session.executor_tree.executor_result in [ResultState.ERROR, ResultState.FAILURE]:
-            exit(ExitCode.TESTS_FAILED.value)
+            # check if a BalderException was thrown too -> would be a balder environment error -> special exit code
+            balder_exceptions = [cur_exc for cur_exc in balder_session.executor_tree.get_all_recognized_exception()
+                                 if isinstance(cur_exc, BalderException)]
+            if len(balder_exceptions) > 0:
+                exit(ExitCode.BALDER_USAGE_ERROR.value)
+            else:
+                exit(ExitCode.TESTS_FAILED.value)
 
     except BalderException as exc:
         # a balder usage error occurs

--- a/src/_balder/console/balder.py
+++ b/src/_balder/console/balder.py
@@ -4,6 +4,8 @@ import pathlib
 import sys
 import traceback
 from typing import Callable, Optional, Union, List
+from _balder.exit_code import ExitCode
+from _balder.testresult import ResultState
 from _balder.exceptions import BalderException
 from _balder.balder_session import BalderSession
 
@@ -28,13 +30,22 @@ def _console_balder_debug(cmd_args: Optional[List[str]] = None, working_dir: Uni
         if cb_run_finished:
             cb_run_finished(balder_session)
 
+        if balder_session.executor_tree is None:
+            exit(ExitCode.SUCCESS.value)
+        elif balder_session.executor_tree.executor_result == ResultState.SUCCESS:
+            exit(ExitCode.SUCCESS.value)
+        elif balder_session.executor_tree.executor_result in [ResultState.ERROR, ResultState.FAILURE]:
+            exit(ExitCode.TESTS_FAILED.value)
+
     except BalderException as exc:
         # a balder usage error occurs
         if cb_balder_exc:
             cb_balder_exc(exc)
         traceback.print_exception(*sys.exc_info())
+        exit(ExitCode.BALDER_USAGE_ERROR.value)
     except Exception as exc:
         # a unexpected error occurs
         if cb_unexpected_exc:
             cb_unexpected_exc(exc)
         traceback.print_exception(*sys.exc_info())
+        exit(ExitCode.UNEXPECTED_ERROR.value)

--- a/src/_balder/executor/basic_executor.py
+++ b/src/_balder/executor/basic_executor.py
@@ -108,6 +108,23 @@ class BasicExecutor(ABC):
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
+    def get_all_recognized_exception(self) -> List[Exception]:
+        """
+        This method returns all occurred Exception of this branch.
+
+        :return: a list with all occurred and recorded exceptions
+        """
+        all_own = [self.construct_result.exception, self.body_result.exception, self.teardown_result.exception]
+        if self.all_child_executors:
+            for cur_child_executor in self.all_child_executors:
+                all_own += cur_child_executor.get_all_recognized_exception()
+
+        # filter all duplicated entries
+        all_own = list(set(all_own))
+        if None in all_own:
+            all_own.remove(None)
+        return all_own
+
     def set_result_for_whole_branch(self, value: ResultState):
         """
         This method sets the executor result for all sub executors.

--- a/src/_balder/exit_code.py
+++ b/src/_balder/exit_code.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class ExitCode(Enum):
+    #: tests were collected and all tests and fixtures terminates with success
+    SUCCESS = 0
+    #: tests were collected but some tests failed
+    TESTS_FAILED = 1
+    #: test was interrupted by user
+    USER_INTERRUPT = 2
+    #: an internal unexpected error occurs
+    UNEXPECTED_ERROR = 3
+    #: Balder usage error
+    BALDER_USAGE_ERROR = 4
+    #: no tests were collected
+    NO_TESTS_COLLECTED = 5

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobScenarioConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobScenarioTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobSessionConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobSessionTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobSetupConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobSetupTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobTestcaseConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobTestcaseTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobVariationConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtBalderglobVariationTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
@@ -26,6 +26,10 @@ class Test0TreecheckFixtScenarioaSessionConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaSessionTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaSetupTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
@@ -26,6 +26,10 @@ class Test0TreecheckFixtSetupaSessionConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaSessionTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaSetupTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
@@ -24,6 +24,10 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
@@ -25,6 +25,10 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
@@ -23,6 +23,10 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
         ]
 
     @property
+    def expected_exit_code(self):
+        return 1
+
+    @property
     def expected_data(self):
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
+++ b/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
@@ -20,6 +20,10 @@ class Test0UnclearSetupScopedFixtureReference(Base0EnvtesterClass):
     """
 
     @property
+    def expected_exit_code(self) -> int:
+        return 4
+
+    @property
     def expected_data(self) -> tuple:
         return (
             # FIXTURE-CONSTRUCTION: balderglob_fixture_session

--- a/tests/scenario_inheritance/test_0_scenario_missing_device_inheritance/test_0_scenario_inheritance_missing_device_inheritance.py
+++ b/tests/scenario_inheritance/test_0_scenario_missing_device_inheritance/test_0_scenario_inheritance_missing_device_inheritance.py
@@ -20,6 +20,10 @@ class Test0ScenarioInheritanceMissingDeviceInheritance(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, DeviceOverwritingError), 'unexpected exception type'

--- a/tests/scenario_inheritance/test_0_scenario_overwrite_only_one_device/test_0_scenario_inheritance_overwrite_only_one_device.py
+++ b/tests/scenario_inheritance/test_0_scenario_overwrite_only_one_device/test_0_scenario_inheritance_overwrite_only_one_device.py
@@ -20,6 +20,10 @@ class Test0ScenarioInheritanceOverwriteOnlyOneDevice(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, DeviceOverwritingError), 'unexpected exception type'

--- a/tests/setup_inheritance/test_0_setup_missing_device_inheritance/test_0_setup_inheritance_missing_device_inheritance.py
+++ b/tests/setup_inheritance/test_0_setup_missing_device_inheritance/test_0_setup_inheritance_missing_device_inheritance.py
@@ -20,6 +20,10 @@ class Test0SetupInheritanceMissingDeviceInheritance(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, DeviceOverwritingError), 'unexpected error type'

--- a/tests/setup_inheritance/test_0_setup_overwrite_only_one_device/test_0_setup_inheritance_overwrite_only_one_device.py
+++ b/tests/setup_inheritance/test_0_setup_overwrite_only_one_device/test_0_setup_inheritance_overwrite_only_one_device.py
@@ -21,6 +21,10 @@ class Test0SetupInheritanceOverwriteOnlyOneDevice(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, DeviceOverwritingError), 'unexpected exception type'

--- a/tests/test_utilities/base_0_envtester_class.py
+++ b/tests/test_utilities/base_0_envtester_class.py
@@ -59,7 +59,8 @@ class Base0EnvtesterClass(ABC):
 
         proc.join()
         assert proc.exitcode == self.expected_exit_code, \
-            f"the process does not terminates with expected exit code `{self.expected_exit_code}`"
+            f"the process terminates with unexpected exit code `{proc.exitcode}` - exit code " \
+            f"`{self.expected_exit_code}` was expected"
 
         if self.expected_data_alternative is None:
             # only one possible truth

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_illegally_befsce/test_0_feat_overwrite_illegally_befsce.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_illegally_befsce/test_0_feat_overwrite_illegally_befsce.py
@@ -24,6 +24,10 @@ class Test0FeatOverwriteIllegallyBefsce(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, FeatureOverwritingError), 'unexpected error type'

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_illegally_betsceset/test_0_feat_overwrite_illegally_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_illegally_betsceset/test_0_feat_overwrite_illegally_betsceset.py
@@ -24,6 +24,10 @@ class Test0FeatOverwriteIllegallyBetsceset(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, FeatureOverwritingError), "wrong exception type"

--- a/tests/vdevice/inheritance/test_0_overwrite_illegally_befsce/test_0_overwrite_illegally_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_illegally_befsce/test_0_overwrite_illegally_befsce.py
@@ -22,6 +22,10 @@ class Test0OverwriteIllegallyBefsce(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, VDeviceOverwritingError), 'unexpected exception type'

--- a/tests/vdevice/inheritance/test_0_overwrite_illegally_betsceset/test_0_overwrite_illegally_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_illegally_betsceset/test_0_overwrite_illegally_betsceset.py
@@ -22,6 +22,10 @@ class Test0OverwriteIllegallyBetsceset(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, VDeviceOverwritingError), 'unexpected exception type'

--- a/tests/vdevice/inheritance/test_0_overwrite_illegally_miss_inherit_befsce/test_0_overwrite_illegally_miss_inherit_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_illegally_miss_inherit_befsce/test_0_overwrite_illegally_miss_inherit_befsce.py
@@ -23,6 +23,10 @@ class Test0OverwriteIllegallyMissInheritBefsce(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, VDeviceOverwritingError), 'unexpected exception type'

--- a/tests/vdevice/inheritance/test_0_overwrite_illegally_miss_inherit_betsceset/test_0_overwrite_illegally_miss_inherit_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_illegally_miss_inherit_betsceset/test_0_overwrite_illegally_miss_inherit_betsceset.py
@@ -23,6 +23,10 @@ class Test0OverwriteIllegallyMissInheritBetsceset(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self) -> int:
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, VDeviceOverwritingError), 'unexpected exception type'

--- a/tests/vdevice/test_0_vdevice_mapping_in_vdevice_feature_scenario/test_0_vdevice_mapping_in_vdevice_feature_scenario.py
+++ b/tests/vdevice/test_0_vdevice_mapping_in_vdevice_feature_scenario/test_0_vdevice_mapping_in_vdevice_feature_scenario.py
@@ -16,6 +16,10 @@ class Test0VdeviceMappingInVdeviceFeatureScenario(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self):
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert isinstance(exc, IllegalVDeviceMappingError), \

--- a/tests/vdevice/test_0_vdevice_mapping_in_vdevice_feature_setup/test_0_vdevice_mapping_in_vdevice_feature_setup.py
+++ b/tests/vdevice/test_0_vdevice_mapping_in_vdevice_feature_setup/test_0_vdevice_mapping_in_vdevice_feature_setup.py
@@ -16,6 +16,10 @@ class Test0VdeviceMappingInVdeviceFeatureSetup(Base0EnvtesterClass):
     def expected_data(self) -> tuple:
         return ()
 
+    @property
+    def expected_exit_code(self):
+        return 4
+
     @staticmethod
     def handle_balder_exception(exc: BalderException):
         assert exc.args[0] == "the feature `SetupFeatureI` you have instantiated in your vDevice `OtherVDevice1` of " \


### PR DESCRIPTION
This PR introduces a new exit-code object that secures that balder returns a exit code depending on its state:

```python

from enum import Enum


class ExitCode(Enum):
    #: tests were collected and all tests and fixtures terminates with success
    SUCCESS = 0
    #: tests were collected but some tests failed
    TESTS_FAILED = 1
    #: test was interrupted by user
    USER_INTERRUPT = 2
    #: an internal unexpected error occurs
    UNEXPECTED_ERROR = 3
    #: Balder usage error
    BALDER_USAGE_ERROR = 4
    #: no tests were collected
    NO_TESTS_COLLECTED = 5


```

In addition this PR introduces a new method `basic_executor.get_all_recognized_exception()`, that returns all recognized exceptions of the current considered branch. This method is used to determine if a runtime error is a balder environment error, by checking if the exception is a subclass of `BalderException`.