### PR TITLE
combine `collector.set_original_device_features_for()` and `collector.set_original_device_features_for_all_vdevices_of()` by using `BaseDeviceController.save_all_original_instanced_features()`

### DIFF
--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -673,15 +673,7 @@ class Collector:
             vdevices = cur_feature_controller.get_abs_inner_vdevice_classes()
             for cur_vdevice in vdevices:
                 cur_vdevice_controller = VDeviceController.get_for(cur_vdevice)
-                new_originals = cur_vdevice_controller.get_all_instantiated_feature_objects()
-
-                if cur_vdevice_controller.get_original_instanced_feature_objects():
-                    if cur_vdevice_controller.get_original_instanced_feature_objects() != new_originals:
-                        raise EnvironmentError(
-                            f"the vDevice `{cur_vdevice.__name__}` already has a static attribute value in "
-                            f"`Device.__original_instanced_features`")
-
-                cur_vdevice_controller.set_original_instanced_feature_objects(new_originals)
+                cur_vdevice_controller.save_all_original_instanced_features()
 
     @staticmethod
     def feature_validate_inner_classes(features: List[Type[Feature]]):

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -279,14 +279,7 @@ class Collector:
             devices = cur_scenario_or_setup_controller.get_all_abs_inner_device_classes()
             for cur_device in devices:
                 cur_device_controller = DeviceController.get_for(cur_device)
-                new_originals = cur_device_controller.get_all_instantiated_feature_objects()
-                if cur_device_controller.get_original_instanced_feature_objects():
-                    if cur_device_controller.get_original_instanced_feature_objects() != new_originals:
-                        raise EnvironmentError(
-                            f"the device `{cur_device.__name__}` already has a static attribute value in "
-                            f"`Device.__original_instanced_features`")
-
-                cur_device_controller.set_original_instanced_feature_objects(new_originals)
+                cur_device_controller.save_all_original_instanced_features()
 
     @staticmethod
     def validate_inheritance_of(items: List[Union[Type[Setup], Type[Scenario]]]):

--- a/src/_balder/controllers/base_device_controller.py
+++ b/src/_balder/controllers/base_device_controller.py
@@ -71,3 +71,21 @@ class BaseDeviceController(Controller, ABC):
             self._original_instanced_features = None
         else:
             self._original_instanced_features = data
+
+    def save_all_original_instanced_features(self):
+        """
+        This property sets the internal dictionary about the original instantiated features of this
+        :class:`Device`/:class:`VDevice`. This is done, to ensure that balder has saved an original copy of the original
+        instantiated abstract features. The real features will be overwritten for each new variation by the
+        :class:`ExecutorTree`!
+        """
+        new_originals = self.get_all_instantiated_feature_objects()
+
+        if self.get_original_instanced_feature_objects():
+            if self.get_original_instanced_feature_objects() != new_originals:
+                # todo we should use a balder exception here!!
+                raise EnvironmentError(
+                    f"the `{self.__class__.__name__}` for the item `{self.related_cls.__name__}` already has a static "
+                    f"attribute value for its original instanced feature objects - can not overwrite it again")
+
+        self.set_original_instanced_feature_objects(new_originals)


### PR DESCRIPTION
This PR uses the `BaseDeviceController` to provide the similar implementation for `collector.set_original_device_features_for()` and `collector.set_original_device_features_for_all_vdevices_of()`.