### PR TITLE
refactor method `collector.exchange_vdevice_mapping_device_strings()`

### DIFF
--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -522,33 +522,15 @@ class Collector:
         VDevice-Device mappings for every instantiated :class:`.Feature`, if the mapped device (value in constructor)
         is given as a string.
         """
-        def exchange_string_for_vdevice_class_in(device: Type[Device], in_classes: List[Type[Device]]):
-            all_instanced_features = DeviceController.get_for(device).get_original_instanced_feature_objects()
-            if all_instanced_features is None:
-                # has no features -> skip
-                return
-            for _, cur_feature in all_instanced_features.items():
-                if cur_feature.active_vdevices != {}:
-                    # do something only if there exists an internal mapping
-                    for cur_mapped_vdevice, cur_mapped_device in cur_feature.active_vdevices.items():
-                        if isinstance(cur_mapped_device, str):
-                            resolved_device = [cur_possible_device for cur_possible_device in in_classes
-                                               if cur_possible_device.__name__ == cur_mapped_device]
-                            if len(resolved_device) != 1:
-                                raise RuntimeError(
-                                    f"found none or more than one possible name matching while trying to resolve "
-                                    f"the given vDevice string `{cur_mapped_vdevice}` in feature "
-                                    f"`{cur_feature.__class__.__name__}`")
-                            cur_feature.active_vdevices[cur_mapped_vdevice] = resolved_device[0]
 
         for cur_scenario in self._all_scenarios:
             scenario_devices = ScenarioController.get_for(cur_scenario).get_all_abs_inner_device_classes()
             for cur_device in scenario_devices:
-                exchange_string_for_vdevice_class_in(device=cur_device, in_classes=scenario_devices)
+                DeviceController.get_for(cur_device).resolve_mapped_vdevice_strings()
         for cur_setup in self._all_setups:
             setup_devices = SetupController.get_for(cur_setup).get_all_abs_inner_device_classes()
             for cur_device in setup_devices:
-                exchange_string_for_vdevice_class_in(device=cur_device, in_classes=setup_devices)
+                DeviceController.get_for(cur_device).resolve_mapped_vdevice_strings()
 
     def get_all_scenario_feature_classes(self) -> List[Type[Feature]]:
         """

--- a/src/_balder/controllers/normal_scenario_setup_controller.py
+++ b/src/_balder/controllers/normal_scenario_setup_controller.py
@@ -77,6 +77,23 @@ class NormalScenarioSetupController(Controller, ABC):
             filtered_classes.append(cur_class)
         return filtered_classes
 
+    def get_inner_device_class_by_string(self, device_str: str) -> Union[Type[Device], None]:
+        """
+        This method returns the inner Device class for the given string.
+
+        :param device_str: the name string of the Device that should be returned
+
+        :return: the Device class or None, if the method has not found any class with this name
+        """
+        possible_devs = [cur_vdevice for cur_vdevice in self.get_all_inner_device_classes()
+                         if cur_vdevice.__name__ == device_str]
+        if len(possible_devs) == 0:
+            return None
+        if len(possible_devs) > 1:
+            raise RuntimeError("found more than one possible vDevices - something unexpected happened")
+
+        return possible_devs[0]
+
     def get_all_abs_inner_device_classes(self) -> List[Type[Device]]:
         """
         This method provides a list of all :meth:`Device` classes that are valid for the related scenario or setup
@@ -94,6 +111,23 @@ class NormalScenarioSetupController(Controller, ABC):
             return self.__class__.get_for(base_class).get_all_abs_inner_device_classes()
 
         return cls_devices
+
+    def get_abs_inner_device_class_by_string(self, device_str: str) -> Union[Type[Device], None]:
+        """
+        This method returns the absolute inner Device class for the given string.
+
+        :param device_str: the name string of the Device that should be returned
+
+        :return: the Device class or None, if the method has not found any class with this name
+        """
+        possible_devs = [cur_vdevice for cur_vdevice in self.get_all_abs_inner_device_classes()
+                         if cur_vdevice.__name__ == device_str]
+        if len(possible_devs) == 0:
+            return None
+        if len(possible_devs) > 1:
+            raise RuntimeError("found more than one possible vDevices - something unexpected happened")
+
+        return possible_devs[0]
 
     @abstractmethod
     def get_next_parent_class(self) -> Union[Type[Scenario], Type[Setup], None]:


### PR DESCRIPTION
This PR moves the main implementation of method `collector.exchange_vdevice_mapping_device_strings()` into `device_controller.resolve_mapped_vdevice_strings()`.

It also introduces two more methods `normal_scenario_setup_controller.get_inner_device_class_by_string()` and `normal_scenario_setup_controller.get_abs_inner_device_class_by_string()`.