### PR TITLE
cleanup `collector.collect()` method

### DIFF
--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -586,31 +586,6 @@ class Collector:
             cur_feature_controller.validate_inner_vdevice_inheritance()
 
     @staticmethod
-    def feature_determine_class_for_vdevice_values(features: List[Type[Feature]], print_warning=True):
-        """
-        This method determines the absolute class based values for `@for_vdevice`. It will do nothing if the value was
-        already set by an explicit class based `@for_vdevice` decorator. In this case the method only checks that
-        every given vDevice class is a real part of the current :class:`Feature` class (will be returned by direct call
-        of method `Feature.get_inner_vdevice_classes()`). Otherwise, it determines the class based `@for_vdevice`
-        value through analysing of the method based decorators and sets this determined value. If the method has to
-        determine the value, it throws a warning with a suggestion for a nice class based decorator. Also, here the
-        method will analyse the given vDevice classes and secures that they are defined in the current :class:`Feature`
-        class.
-
-        .. note::
-            This method automatically updates the values for the parent classes, too. Every time it searches for the
-            values it considers the parent values for the vDevice or the parent class of the vDevice, too.
-
-        .. note::
-            This method can throw a user warning (`throw_warning` has to be True for that), but only on the given list
-            of :class:`Feature` classes. All parent :class:`Feature` classes will be determined correctly, but will not
-            throw a waring.
-        """
-        for cur_feature in features:
-            cur_feature_controller = FeatureController.get_for(cur_feature)
-            cur_feature_controller.get_absolute_class_based_for_vdevice(print_warning)
-
-    @staticmethod
     def check_vdevice_feature_existence(items: Union[List[Type[Scenario]], List[Type[Setup]]]):
         """
         This method validates that the :class:`Feature` property set of a :class:`Device` holds all required
@@ -713,7 +688,7 @@ class Collector:
         Collector.feature_validate_vdevice_inheritance(all_scenario_features)
         Collector.feature_validate_vdevice_inheritance(all_setup_features)
 
-    def _determine_class_based_values_for_all_features(self):
+    def _determine_class_based_values_for_all_features(self, print_warning=True):
         """
         This method determines the absolute class based values for `@for_vdevice`. It will not update any internal
         values if the class-based-value was already set by an explicit class based `@for_vdevice` decorator. Otherwise,
@@ -729,11 +704,9 @@ class Collector:
             This method automatically updates the values for the parent classes, too. Every time it searches for the
             values it also considers the parent values for the vDevice or the parent class of the vDevice.
         """
-        all_scenario_features = self.get_all_scenario_feature_classes()
-        all_setup_features = self.get_all_setup_feature_classes()
-
-        Collector.feature_determine_class_for_vdevice_values(all_scenario_features)
-        Collector.feature_determine_class_for_vdevice_values(all_setup_features)
+        for cur_feature in self.get_all_scenario_feature_classes() + self.get_all_setup_feature_classes():
+            cur_feature_controller = FeatureController.get_for(cur_feature)
+            cur_feature_controller.get_absolute_class_based_for_vdevice(print_warning)
 
     def _validate_vdevice_feature_references(self):
         """

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -636,16 +636,6 @@ class Collector:
         for cur_feature in features:
             FeatureController.get_for(cur_feature).validate_inherited_class_based_vdevice_cnn_subset()
 
-    def determine_raw_absolute_device_connections_for(self, items: Union[List[Type[Scenario]], List[Type[Setup]]]):
-        """
-        This method determines and creates the basic `_absolute_connections` for the given scenarios or setups. Note,
-        that this method only creates the class attribute and adds the synchronized connections (same on both sides if
-        they are bidirectional). It does not analyse or take :class:`Feature` classes into consideration.
-        """
-
-        for cur_scenario_or_setup in items:
-            NormalScenarioSetupController.get_for(cur_scenario_or_setup).determine_raw_absolute_device_connections()
-
     def validate_feature_clearance_for_parallel_connections_for_scenarios(self, scenarios: List[Type[Scenario]]):
         """
         This method validates for every active class-based feature (only the ones that have a active VDevice<->Device
@@ -655,20 +645,6 @@ class Collector:
         """
         for cur_scenario in scenarios:
             ScenarioController.get_for(cur_scenario).validate_feature_clearance_for_parallel_connections()
-
-    def determine_absolute_device_connections_for_scenarios(self, items: List[Type[Scenario]]):
-        """
-        This method determines the real possible Sub-Connections for every element of the scenarios. For this the method
-        will create a possible intersection connection, for the :class:´Connection´ between two devices and
-        all :class:`Connection`-Subtrees that are allowed for the mapped vDevices in the used :class:`Feature`
-        classes.
-        The data will be saved in the :class:`Device` property ``_absolute_connections``. If the method detects an empty
-        intersection between two devices that are connected through a VDevice-Device mapping, the method will throw an
-        exception.
-        """
-
-        for cur_scenario in items:
-            ScenarioController.get_for(cur_scenario).determine_absolute_device_connections()
 
     def _set_original_device_features(self):
         """
@@ -776,9 +752,13 @@ class Collector:
         determines the raw absolute connections for scenarios and setups and also creates the real device connections
         for all scenarios.
         """
-        self.determine_raw_absolute_device_connections_for(self.all_scenarios)
-        self.determine_raw_absolute_device_connections_for(self.all_setups)
-        self.determine_absolute_device_connections_for_scenarios(self.all_scenarios)
+        # determine the raw absolute device connections for all scenarios and setups
+        for cur_scenario_or_setup in self.all_scenarios_and_setups:
+            NormalScenarioSetupController.get_for(cur_scenario_or_setup).determine_raw_absolute_device_connections()
+
+        # determine all absolute device connections (only for scenarios)
+        for cur_scenario in self.all_scenarios:
+            ScenarioController.get_for(cur_scenario).determine_absolute_device_connections()
 
     def _validate_feature_connections_in_setup(self):
         """

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -276,20 +276,6 @@ class Collector:
                 result.append(cur_class)
         return result
 
-    @staticmethod
-    def validate_inheritance_of(items: List[Union[Type[Setup], Type[Scenario]]]):
-        """
-        This method validates that the inheritance of `Setup`/`Scenario` classes were being done correctly. It checks
-        that all devices that are inherited has the same naming as their parents and also that every reused name (that
-        is already be used for a device in parent class) does also inherit from the parent scenario/setup device.
-
-        In addition to that, the method checks that either every device of higher class is defined (and overwritten) in
-        the current class or non device
-        """
-        for cur_scenario_or_setup in items:
-            cur_scenario_or_setup_controller = NormalScenarioSetupController.get_for(cur_scenario_or_setup)
-            cur_scenario_or_setup_controller.validate_inheritance()
-
     def set_run_skip_ignore_of_test_methods_in_scenarios(self):
         """
         This method secures that the scenario classes have a valid RUN, SKIP and IGNORE attribute.
@@ -731,10 +717,16 @@ class Collector:
 
     def _validate_scenario_and_setups(self):
         """
-        This method validates the scenario and setups that are collected.
+        This method validates that the inheritance of `Setup`/`Scenario` classes were being done correctly. It checks
+        that all devices that are inherited has the same naming as their parents and also that every reused name (that
+        is already be used for a device in parent class) does also inherit from the parent scenario/setup device.
+
+        In addition to that, the method checks that either every device of higher class is defined (and overwritten) in
+        the current class or non device
         """
-        Collector.validate_inheritance_of(self._all_scenarios)
-        Collector.validate_inheritance_of(self._all_setups)
+        for cur_scenario_or_setup in self.all_scenarios_and_setups:
+            cur_scenario_or_setup_controller = NormalScenarioSetupController.get_for(cur_scenario_or_setup)
+            cur_scenario_or_setup_controller.validate_inheritance()
 
     def _validate_features_and_their_vdevices(self):
         """

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -670,15 +670,6 @@ class Collector:
         for cur_scenario in items:
             ScenarioController.get_for(cur_scenario).determine_absolute_device_connections()
 
-    @staticmethod
-    def validate_feature_possibility_in_setups(setups: List[Type[Setup]]):
-        """
-        This method validates that every feature connection (that already has a vDevice<->Device mapping on setup level)
-        has a connection that is CONTAINED-IN the connection of the related setup devices.
-        """
-        for cur_setup in setups:
-            SetupController.get_for(cur_setup).validate_feature_possibility()
-
     def _set_original_device_features(self):
         """
         This method ensures that the original features (that are instantiated in the
@@ -795,7 +786,8 @@ class Collector:
         It ensures, that every feature connection (that already has a vDevice<->Device mapping on setup level)
         has a connection that is CONTAINED-IN the connection between the related setup devices.
         """
-        Collector.validate_feature_possibility_in_setups(self.all_setups)
+        for cur_setup in self.all_setups:
+            SetupController.get_for(cur_setup).validate_feature_possibility()
 
     def collect(self, plugin_manager: PluginManager):
         """


### PR DESCRIPTION
This PR removes the old collector helper method and separates the `collect()` method in higher group methods. It removes some collector methods and integrates them into the higher group methods, that were introduces with this PR.