### PR TITLE
use setuptools_scm for version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+/src/_balder/_version.py

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,14 +12,17 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../src'))
-
 from balder import __version__
+
+sys.path.insert(0, os.path.abspath('../../src'))
 
 # -- Project information -----------------------------------------------------
 
 project = 'balder'
 version = __version__
+# only use major/minor here
+release = ".".join(version.split(".")[:2])
+
 copyright = '2021, Max Stahlschmidt'
 author = 'Max Stahlschmidt'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/_balder/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = baldertest
-version=0.1.0b2
+use_scm_version=True
 description = balder: reusable scenario based test framework
 author = Max Stahlschmidt and others
 long_description = file: README.md

--- a/src/_balder/__init__.py
+++ b/src/_balder/__init__.py
@@ -1,4 +1,12 @@
 
 __all__ = [
+    "__version__",
 
+    "__version_tuple__"
 ]
+
+try:
+    from ._version import __version__, __version_tuple__
+except ImportError:
+    __version__ = ""
+    __version_tuple__ = tuple()

--- a/src/balder/__init__.py
+++ b/src/balder/__init__.py
@@ -1,3 +1,4 @@
+from _balder import __version__, __version_tuple__
 from _balder.setup import Setup
 from _balder.device import Device
 from _balder.vdevice import VDevice
@@ -14,6 +15,10 @@ from _balder.decorator_insert_into_tree import insert_into_tree
 
 
 __all__ = [
+    '__version__',
+
+    '__version_tuple__',
+
     'connect',
 
     'fixture',
@@ -40,5 +45,3 @@ __all__ = [
 
     'BalderSettings'
 ]
-
-__version__ = '0.0.1b2'


### PR DESCRIPTION
This PR change the build process to use `setuptools_scm` for auto-generating the version from git.