### PR TITLE
add absolute methods for handling calculated class based @for_vdevice decorator data

### DIFF
--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -624,7 +624,7 @@ class Collector:
         """
         for cur_feature in self.get_all_scenario_feature_classes() + self.get_all_setup_feature_classes():
             cur_feature_controller = FeatureController.get_for(cur_feature)
-            cur_feature_controller.get_absolute_class_based_for_vdevice(print_warning)
+            cur_feature_controller.determine_absolute_class_based_for_vdevice(print_warning)
 
     def _validate_vdevice_feature_references(self):
         """

--- a/src/_balder/controllers/feature_controller.py
+++ b/src/_balder/controllers/feature_controller.py
@@ -151,7 +151,7 @@ class FeatureController(Controller):
         """
         self._cls_for_vdevice = data
 
-    def get_absolute_class_based_for_vdevice(self, print_warning):
+    def determine_absolute_class_based_for_vdevice(self, print_warning):
         """
 
         This method determines the absolute class based `@for_vdevice` value for the related feature.
@@ -179,7 +179,7 @@ class FeatureController(Controller):
         # with the following recursive call we guarantee that the next parent class has the correct resolved class
         #  based @for_vdevice information
         if next_parent_feat:
-            FeatureController.get_for(next_parent_feat).get_absolute_class_based_for_vdevice(print_warning=False)
+            FeatureController.get_for(next_parent_feat).determine_absolute_class_based_for_vdevice(print_warning=False)
 
         # validate if all used vDevice references in method and class based `@for_vdevice` decorators can be used,
         # because they are members of this feature

--- a/src/_balder/controllers/scenario_controller.py
+++ b/src/_balder/controllers/scenario_controller.py
@@ -126,7 +126,7 @@ class ScenarioController(NormalScenarioSetupController):
                 # now check if one or more single of the classbased connection are CONTAINED IN the possible
                 # parallel connection (only if there exists more than one parallel)
                 feature_cnn = Connection.based_on(*FeatureController.get_for(
-                        cur_feature.__class__).get_class_based_for_vdevice()[mapped_vdevice])
+                        cur_feature.__class__).get_abs_class_based_for_vdevice()[mapped_vdevice])
 
                 # search node names that is the relevant connection
                 relevant_cnns: List[Connection] = []
@@ -250,7 +250,7 @@ class ScenarioController(NormalScenarioSetupController):
                 # now try to reduce the scenario connections according to the requirements of the feature class
                 cur_feature_class_based_for_vdevice = \
                     FeatureController.get_for(
-                        cur_feature.__class__).get_class_based_for_vdevice()[mapped_vdevice]
+                        cur_feature.__class__).get_abs_class_based_for_vdevice()[mapped_vdevice]
                 cur_feature_cnn = Connection.based_on(*cur_feature_class_based_for_vdevice)
 
                 device_cnn_singles = get_single_cnns_between_device_for_feature(

--- a/src/_balder/controllers/setup_controller.py
+++ b/src/_balder/controllers/setup_controller.py
@@ -107,7 +107,7 @@ class SetupController(NormalScenarioSetupController):
                     continue
 
                 cur_feature_controller = FeatureController.get_for(cur_feature.__class__)
-                feature_class_based_for_vdevice = cur_feature_controller.get_class_based_for_vdevice()
+                feature_class_based_for_vdevice = cur_feature_controller.get_abs_class_based_for_vdevice()
                 if not feature_class_based_for_vdevice or mapped_vdevice not in feature_class_based_for_vdevice.keys():
                     # there exists no class based for vdevice information (at least for the current active vdevice)
                     continue

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -657,7 +657,7 @@ class VariationExecutor(BasicExecutor):
                 # here)
                 feature_cnns = \
                     FeatureController.get_for(
-                        cur_setup_feature.__class__).get_class_based_for_vdevice()[cur_setup_feature_vdevice]
+                        cur_setup_feature.__class__).get_abs_class_based_for_vdevice()[cur_setup_feature_vdevice]
                 # connection that are relevant for this feature
                 relevant_cnns = abs_var_scenario_device_cnns[cur_scenario_device][cur_mapped_scenario_device]
 


### PR DESCRIPTION
Similar to the mechanism for absolute connections and devices, also the VDevice methods should exist as absolute and original defined variants. This PR introduce it into the `FeatureController`. 
