### PR TITLE
fix bug that vdevice mappings could be assigned to more than one vdevice

### DIFF
--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -222,8 +222,11 @@ class VariationExecutor(BasicExecutor):
 
                     # now check if there is a mapping on setup level too
                     for cur_replacing_feature in replacing_features:
-                        _, mapped_setup_device = cur_replacing_feature.active_vdevice_device_mapping
-                        if mapped_setup_device is not None and \
+                        mapped_setup_vdevice, mapped_setup_device = cur_replacing_feature.active_vdevice_device_mapping
+                        if mapped_setup_vdevice is not None and not issubclass(mapped_setup_vdevice, used_scenario_vdevice):
+                            # drop this feature matching, because we have different vdevice mapped
+                            cleanup_replacing_features.remove(cur_replacing_feature)
+                        elif mapped_setup_device is not None and \
                                 mapped_setup_device != to_scenarios_vdevice_mapped_setup_device:
                             # drop this feature matching, because it is not applicable here
                             cleanup_replacing_features.remove(cur_replacing_feature)


### PR DESCRIPTION
This PR fixes a bug, that allows to assign devices to two different VDevices of a feature, by setting one in Scenario and another one in Setup. With this PR, this is not possible anymore and these variations will be ignored.