### PR TITLE
add absolute path of working directory to `sys.path`

### DIFF
--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -74,6 +74,9 @@ class BalderSession:
         if working_dir:
             self.working_dir = working_dir
 
+        # add the current working variable to sys.path
+        sys.path.insert(0, str(self.working_dir.absolute()))
+
         ##
         # instantiate and initialize all components to completely load the plugins (plugins could access the command
         # line argument parser)


### PR DESCRIPTION
This PR adds the absolute path of the working directory to the `sys.path` list. With this it is not required to add the working directory to the `PYTHONPATH` (before executing Balder) anymore.