### PR TITLE
Documentation: add work-in-progress statement to all sections of basic and deeper

### DIFF
--- a/doc/source/basics/balderhub.rst
+++ b/doc/source/basics/balderhub.rst
@@ -22,8 +22,8 @@ provided in these balderhub project. This helps you and your team to develop tes
 
 .. note::
 
-    Balder is a very young project. Unfortunately, this also means that we do not have so many BalderHub projects at the
-    moment.
+    Balder is a very young project. Unfortunately, this also means that we do not have so many
+    `BalderHub projects <https://hub.balder.dev>`_ at the moment.
 
     We need your help here. There are a lot of people in this world, that are experts in the thing they are doing and
     exactly these experts we need here.
@@ -35,11 +35,8 @@ provided in these balderhub project. This helps you and your team to develop tes
     `create an issue <https://github.com/balder-dev/hub.balder.dev/issues>`_ or
     `start a new discussion <https://github.com/balder-dev/hub.balder.dev/discussions>`_.
 
-    Of course you could develop the project by your own too. But if you want to release it, we would really like to add
-    it into our group. Currently, we are working on a specific section in our documentation that should provide a big
-    overview about all existing BalderHub projects. We will release this shortly. If you provide your package within the
-    `Balder GitHub Group <https://github.com/balder-dev>`_, we can secure to add your package as soon as possible. Of
-    course you will remain maintainer of the project.
+    If you want to add your package within the `BalderHub projects <https://hub.balder.dev>`_, just ask for help by
+    creating `an issue in the main hub project <https://github.com/balder-dev/hub.balder.dev/issues>`_.
 
 Where can I search for?
 =======================

--- a/doc/source/basics/balderhub.rst
+++ b/doc/source/basics/balderhub.rst
@@ -1,8 +1,11 @@
 BalderHub - the share place of tests
 ************************************
 
-.. note::
-    The main navigation web page for BalderHub projects is currently under development, but will be released shortly.
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
 Balder' grand vision is to create a open-source, share place for testing-projects. We call them **BalderHub** packages.
 These packages are normal python packages. You can easily install them like normal python package and simply include

--- a/doc/source/basics/configuration.rst
+++ b/doc/source/basics/configuration.rst
@@ -1,6 +1,12 @@
 Configure Balder
 ****************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Console arguments
 =================
 

--- a/doc/source/basics/connections.rst
+++ b/doc/source/basics/connections.rst
@@ -1,6 +1,12 @@
 Connections
 ***********
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 :class:`Connection` objects can be used to define connections between :ref:`Scenario-Devices <Scenario-Device>` and
 :ref:`Setup-Devices <Setup-Device>`. This allows to specify the connections you need (Scenario-Devices) or which
 connections you have (Setup-Devices). So for example, if you have a scenario, that needs a serial connection between

--- a/doc/source/basics/connections.rst
+++ b/doc/source/basics/connections.rst
@@ -93,7 +93,7 @@ Limits of connection-relations
 ------------------------------
 
 You can define **AND**/**OR** definitions in almost any possible variation, but there is one limit.
-It is not allowed to define **AND** connections that on the highest level, so for example:
+It is not allowed to define **AND** connections inside other **AND** connections, so for example:
 
 .. code-block:: python
 
@@ -103,12 +103,12 @@ It is not allowed to define **AND** connections that on the highest level, so fo
     conn = SpecialConnection.based_on((AConnection, BConnection, (CConnection, DConnection)))
 
 The last definition is not allowed because we use an inner **AND** connection there. We can write the same logic more
-easier by refactor the **OR** and **AND** relations:
+easier by refactoring the both **AND** relations:
 
 .. code-block:: python
 
     # same like the NOT ALLOWED tree from above - BUT NOW IT IS ALLOWED
-    conn = SpecialConnection.based_on((AConnection, BConnection, CConnection), (AConnection, BConnection, DConnection)))
+    conn = SpecialConnection.based_on((AConnection, BConnection, CConnection, DConnection)))
 
 This limitation makes it easier to read the logic.
 

--- a/doc/source/basics/devices.rst
+++ b/doc/source/basics/devices.rst
@@ -1,6 +1,12 @@
 Devices
 *******
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 A Device describes a single component of a :ref:`Scenario <Scenarios>` or of a :ref:`Setup <Setups>`. Generally they are
 container classes for a collection of :ref:`Features`.
 

--- a/doc/source/basics/execution_mechanism.rst
+++ b/doc/source/basics/execution_mechanism.rst
@@ -1,6 +1,12 @@
 Balder Execution mechanism
 **************************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 After you start the execution in a balder project with the command line `balder ..`, balder will go through a procedure
 of tree steps. First balder collects all relevant items that can be found in the project directory (the current working
 directory) and imports their balder-related classes and functions. For this purpose balder keeps an internal overview

--- a/doc/source/basics/features.rst
+++ b/doc/source/basics/features.rst
@@ -1,6 +1,12 @@
 Features
 ********
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Features implement functionality for a :ref:`Device <Devices>` class. For example, if you have a device
 that could send messages, this device has to have a :class:`Feature` class that implements the functionality to send
 these messages.

--- a/doc/source/basics/fixtures.rst
+++ b/doc/source/basics/fixtures.rst
@@ -1,6 +1,12 @@
 Fixtures
 ********
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Fixtures are functions or methods that ensure that code is executed before or after specific times of a test run.
 Fixtures can be executed at different times (**execution-level**) and can be defined on different positions
 (**definition-scope**). The order in which these fixtures will be executed, depends on the definition position (in which

--- a/doc/source/basics/scenarios.rst
+++ b/doc/source/basics/scenarios.rst
@@ -1,6 +1,12 @@
 Scenarios
 *********
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 A (test) scenario describes the environment that a test **needs** to be able to be carried out (in contrast to the
 :ref:`Setups` that describes what you **have**). A scenario allows to define a test environment first, after the
 individual test cases will be implemented.

--- a/doc/source/basics/setups.rst
+++ b/doc/source/basics/setups.rst
@@ -1,6 +1,12 @@
 Setups
 ******
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Setup classes describe your real-world test setup. It describes what you **have** (in contrast to the :ref:`Scenarios`,
 that describes what you need). A :class:`Setup` describes the structure of :ref:`Devices` and their relationship to each
 other. It also contains the final implementation of all :ref:`Features` the :ref:`Devices` should have.

--- a/doc/source/basics/vdevices.rst
+++ b/doc/source/basics/vdevices.rst
@@ -1,6 +1,12 @@
 VDevices and method-variations
 ******************************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 During the development of :ref:`Features` you might have noticed, that you require some information from other devices.
 For example if you have a ``LoadSiteFeature``, which allows to load a website or a ``SendMessageFeature``, which allows
 to send a message *to another device*, you need some information about this other device.

--- a/doc/source/deeper/connection_lifecycle.rst
+++ b/doc/source/deeper/connection_lifecycle.rst
@@ -1,5 +1,11 @@
 Connections Lifecycle over stages
 *********************************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Connections will be reduced, optimized and calculated trough the lifecycle of a Balder session. This section shows how
 Balder calculates these connection over the different stages of a Balder test session.

--- a/doc/source/deeper/connections.rst
+++ b/doc/source/deeper/connections.rst
@@ -1,12 +1,13 @@
 Deeper look into Connections
 ****************************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Connections are a important component of the Balder ecosystem. Your connection statements can assume different states.
 This sections help to understand how the connection mechanism is implemented inside balder.
 
-.. warning::
-    Please note: This section is currently under development and will be released shortly!
-
-..
-    .. todo
 

--- a/doc/source/deeper/metadata_management.rst
+++ b/doc/source/deeper/metadata_management.rst
@@ -1,10 +1,10 @@
 Metadata management
 *******************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 Balder uses a lot of inner hidden class properties that manages the workflow of balder. This section describes them.
-
-.. warning::
-    Please note: This section is currently under development and will be released shortly!
-
-..
-    .. todo

--- a/doc/source/deeper/process.rst
+++ b/doc/source/deeper/process.rst
@@ -1,15 +1,10 @@
 Balder process
 **************
 
+.. important::
+
+    .. todo complete reworking of this section
+
+    Please note that this part of the documentation is not yet finished. It will still be revised and updated.
+
 This section describes the process how balder executes a test session and which steps it passes during it.
-
-.. warning::
-    Please note: This section is currently under development and will be released shortly!
-
-..
-    .. todo
-
-First of all, it will collect the test data in the ``Collecting`` process. Afterwards it starts the ``Resolving`` of
-all collected data. It tries to find matchings between :ref:`Setups` and :ref:`Scenarios` and their related
-:ref:`Devices`. After this step has completed, balder tries to create its most important object, the
-:class:`.ExecutorTree`. This object contains the whole session data organized in different specialized executor objects.


### PR DESCRIPTION
This PR adds an work-in-progress state into all basic and deeper sections. In addition it updates the BalderHub page and fixes a bug in the snippet of the inner-AND definition of connections.