### PR TITLE
Documentation: refactor spelling and fix some snippets

### DIFF
--- a/doc/source/api/connections.rst
+++ b/doc/source/api/connections.rst
@@ -11,7 +11,7 @@ see :ref:`Connections`.
 Basic ``Connection``
 ====================
 
-The basic :class:`Connection` class is the master class of every Connection. It can always be used as container for
+The basic :class:`Connection` class is the master class of every connection. It can always be used as container for
 your sub-tree connection too.
 
 .. autoclass:: balder.Connection

--- a/doc/source/api/decorator.rst
+++ b/doc/source/api/decorator.rst
@@ -1,7 +1,7 @@
 Balder Decorators API
 *********************
 
-This is the api documentation of all available balder decorators.
+This is the api documentation of all available Balder decorators.
 
 
 Decorator `@balder.connect(..)`

--- a/doc/source/api/devices.rst
+++ b/doc/source/api/devices.rst
@@ -7,7 +7,7 @@ Every :class:`Scenario` and every :class:`Setup` describes a construction that c
 Basic ``Device``
 ================
 
-The basic :class:`Device` class is the master class of every Device object.
+The basic :class:`Device` class is the master class of every device object.
 
 .. autoclass:: balder.Device
     :members:

--- a/doc/source/api/features.rst
+++ b/doc/source/api/features.rst
@@ -12,7 +12,7 @@ class.
 Basic ``Feature``
 =================
 
-The basic :class:`Feature` class is the master class of every Scenario.
+The basic :class:`Feature` class is the master class of every scenario.
 
 .. autoclass:: balder.Feature
     :members:

--- a/doc/source/api/plugin.rst
+++ b/doc/source/api/plugin.rst
@@ -6,7 +6,7 @@ Balder provides a separate class that helps to implement your own plugin.
 The ``BalderPlugin``
 ====================
 
-The main object to get access to the deep functionality of balder is the :class:`BalderPlugin` class. You can
+The main object to get access to the deep functionality of Balder is the :class:`BalderPlugin` class. You can
 overwrite it in every `balderglob.py` file.
 
 .. autoclass:: balder.BalderPlugin

--- a/doc/source/api/scenarios.rst
+++ b/doc/source/api/scenarios.rst
@@ -8,7 +8,7 @@ Scenarios represents a abstract test setup, that is required to run a testmethod
 Basic ``Scenario``
 ==================
 
-The basic :class:`Scenario` class is the master class of every Scenario.
+The basic :class:`Scenario` class is the master class of every scenario.
 
 .. autoclass:: balder.Scenario
     :members:

--- a/doc/source/api/setups.rst
+++ b/doc/source/api/setups.rst
@@ -8,7 +8,7 @@ Setups describes real-world constellations of custom test environments. They con
 Basic ``Setup``
 ===============
 
-The basic :class:`Setup` class is the master class of every Setup.
+The basic :class:`Setup` class is the master class of every setup.
 
 .. autoclass:: balder.Setup
     :members:

--- a/doc/source/basics/balderhub.rst
+++ b/doc/source/basics/balderhub.rst
@@ -18,7 +18,7 @@ application specific code, but you can reuse different test devices. The idea is
 different tests where a lot of clever minds has already think about. You simply have to inherit from their scenarios,
 add the specific setup-device feature code for your device and go for it. Different mock functions, helper devices or
 complete testable implementations of remote devices (for example a dhcp server for dhcp-client tests) are already
-provided in these balderhub project. This helps you and your team to develop test a lot of faster.
+provided in these BalderHub project. This helps you and your team to develop test a lot of faster.
 
 .. note::
 
@@ -28,7 +28,7 @@ provided in these balderhub project. This helps you and your team to develop tes
     We need your help here. There are a lot of people in this world, that are experts in the thing they are doing and
     exactly these experts we need here.
 
-    Do you know one area really well? Do you like the concept of balder? Think about to initiate an own
+    Do you know one area really well? Do you like the concept of Balder? Think about to initiate an own
     BalderHub project. Take a look into our `Balder GitHub Group <https://github.com/balder-dev>`_ and feel free to
     contribute to an existing project or create your own one. If you are not secure if your subject already exist or
     if you are searching for some colleagues to develop a BalderHub project within a group, fell free to

--- a/doc/source/basics/configuration.rst
+++ b/doc/source/basics/configuration.rst
@@ -37,8 +37,8 @@ to create a new class inside the ``balderglob.py`` file, that inherits from :cla
 BalderPlugin object
 ===================
 
-You can also influence the mechanism of balder by developing balder plugins. For this balder has a global plugin object
-that allows to interact with different callbacks. This helps you to influence the mechanism of the balder system.
+You can also influence the mechanism of Balder by developing Balder plugins. For this Balder has a global plugin object
+that allows to interact with different callbacks. This helps you to influence the mechanism of the Balder system.
 
 .. note::
     The plugin section is still under development. We will integrate and add new callbacks soon!
@@ -46,7 +46,7 @@ that allows to interact with different callbacks. This helps you to influence th
 ..
     .. todo
 
-If you want to create and use a balder plugin, simply create a new child object of :class:`BalderPlugin` and include it
+If you want to create and use a Balder plugin, simply create a new child object of :class:`BalderPlugin` and include it
 in the global ``balderglob.py`` file:
 
 .. code-block:: python

--- a/doc/source/basics/connections.rst
+++ b/doc/source/basics/connections.rst
@@ -24,7 +24,7 @@ This section shows the basic functionality of connections and how you can use th
 Global Connection-Trees
 =======================
 
-Internally balder knows exactly how the connections are arranged with each other. For this it refers to the global
+Internally Balder knows exactly how the connections are arranged with each other. For this it refers to the global
 connection-tree. For example, this tree defines that a :class:`TcpV4Connection` is based on an :class:`IPV4Connection`.
 It also knows that a :class:`HttpConnection` is based on an :class:`TcpV4Connection` or an :class:`TcpV6Connection`.
 
@@ -197,7 +197,7 @@ You are now able to use this connection. It is integrated in the project global 
 Global-Connection-Tree
 ======================
 
-In balder all connections are embedded in a so called global-connection-trees. This tree defines how the connections are
+In Balder all connections are embedded in a so called global-connection-trees. This tree defines how the connections are
 arranged to each other.
 
 The global connection tree
@@ -250,8 +250,8 @@ So let's take a look at the following example:
 .. warning::
 
     Be careful with changing the standard connection tree. With that, there is no connection included in the tree
-    anymore, so you have to define every connection by yourself. If you use standard balder connections
-    note that some BalderHub projects uses the original balder connections.
+    anymore, so you have to define every connection by yourself. If you use standard Balder connections
+    note that some BalderHub projects uses the original Balder connections.
 
     If you want to change the tree dependencies for an existing tree, you can use the class method ``set_parents(..)``.
 

--- a/doc/source/basics/connections.rst
+++ b/doc/source/basics/connections.rst
@@ -21,7 +21,7 @@ especially the :class:`Connection` trees between the devices are important.
 
 This section shows the basic functionality of connections and how you can use them in the Balder ecosystem.
 
-Global Connection-Trees
+Global connection-trees
 =======================
 
 Internally Balder knows exactly how the connections are arranged with each other. For this it refers to the global
@@ -65,7 +65,7 @@ structure:
 
 Balder will automatically resolve UNRESOLVED sub-trees according to its current active global-connection-tree.
 
-OR/AND Connection relations
+OR/AND connection relations
 ===========================
 
 You can combine connection objects with each other. This makes it possible that a connection is based on a connection or
@@ -112,12 +112,12 @@ easier by refactoring the both **AND** relations:
 
 This limitation makes it easier to read the logic.
 
-Using the base Connection object
+Using the base connection object
 ================================
 
-You can use the base Connection object for different use cases.
+You can use the base connection object for different use cases.
 
-General Connection
+General connection
 ------------------
 
 If you want to specify that you need a connection, but it doesn't matter which connection type, you can use
@@ -131,7 +131,7 @@ This is the universal connection that describes a **can-be-everything** connecti
 
 **A general connection does never have based-on elements!**
 
-Container Connection
+Container connection
 --------------------
 
 Sometimes you want to create a statement AConnection OR BConnection. This can easily defined with an container
@@ -143,7 +143,7 @@ connection:
 
 **A container connection always has based-on elements**.
 
-Defining your own Connection
+Defining your own connection
 ============================
 
 Balder allows to define own connections. For that you have to provide a `connections` module somewhere in your project.
@@ -194,10 +194,10 @@ implement this easily:
 
 You are now able to use this connection. It is integrated in the project global connection tree.
 
-Global-Connection-Tree
+Global connection tree
 ======================
 
-In Balder all connections are embedded in a so called global-connection-trees. This tree defines how the connections are
+In Balder all connections are embedded in a so called global connection trees. This tree defines how the connections are
 arranged to each other.
 
 The global connection tree
@@ -207,7 +207,7 @@ Balder provides an global connection tree. This tree is already specified for al
 `<Connections API>`_). Per default Balder uses this pre-defined tree.
 
 .. note::
-    COMING SOON - We are working on a graphical tool to show this global-connection-tree.
+    COMING SOON - We are working on a graphical tool to show this global connection tree.
 
 ..
     .. todo

--- a/doc/source/basics/devices.rst
+++ b/doc/source/basics/devices.rst
@@ -7,7 +7,7 @@ Devices
 
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
-A Device describes a single component of a :ref:`Scenario <Scenarios>` or of a :ref:`Setup <Setups>`. Generally they are
+A device describes a single component of a :ref:`Scenario <Scenarios>` or of a :ref:`Setup <Setups>`. Generally they are
 container classes for a collection of :ref:`Features`.
 
 Scenario-Device
@@ -17,7 +17,7 @@ A :ref:`Scenario-Device` is a device, that defines a subset of :ref:`Features`, 
 have. Balder searches for matches (see also :ref:`Matching process of setups and scenarios (SOLVING)`), where the
 potential :ref:`Setup-Device` has an implementation for the :ref:`Features` of the :ref:`Scenario-Device`.
 
-So when is a :class:`Device` a Scenario-Device? - This depends one the definition location. A :class:`Device` is
+So when is a :class:`Device` a scenario-device? - This depends one the definition location. A :class:`Device` is
 a :ref:`Scenario-Device` when it is an inner-class of a :class:`Scenario`.
 
 .. code-block:: py
@@ -68,7 +68,7 @@ inner-classes in :ref:`Setups` of course.
 
 Often the :ref:`Features` of a :ref:`Setup-Device` implement the complete logic, while the features of the
 :ref:`Scenario-Device` only describes the abstract architecture. This can be done, because the :ref:`Features` of the
-:ref:`Setup-Devices <Setup-Device>` are subclasses of the Scenario-Device :ref:`Features`. You can find more
+:ref:`Setup-Devices <Setup-Device>` are subclasses of the scenario-device :ref:`Features`. You can find more
 information about this in the sections :ref:`Features` and :ref:`Matching process of setups and scenarios (SOLVING)`.
 
 

--- a/doc/source/basics/execution_mechanism.rst
+++ b/doc/source/basics/execution_mechanism.rst
@@ -18,7 +18,7 @@ an execution-tree. In the last step Balder executes this tree with the inclusion
 To make it easier to understand the functionality of Balder, we will start to consider the differences between
 :ref:`Setup <Setups>` classes and :ref:`Scenario <Scenarios>` classes a little bit more in detail.
 
-Difference between Setup and Scenario
+Difference between setup and scenario
 =====================================
 
 Balder is based on individual :ref:`Scenario <Scenarios>` and :ref:`Setup <Setups>` classes.
@@ -59,7 +59,7 @@ Collecting process
 The collection process is the first stage of the Balder execution mechanism, directly after executing the ``balder ...``
 command. In this stage all available relevant Balder classes within the working directory are collected.
 
-Collect Setups and Scenarios
+Collect setups and scenarios
 ----------------------------
 
 First the collector begins to find all setup and scenario classes that are located directly in the Python files
@@ -70,7 +70,7 @@ classes, which are subclasses of the master :class:`Scenario` class and if their
 Only for classes that meet all these criteria, Balder will acknowledge these classes as valid scenarios and add
 them to the internal collection of executable scenarios.
 
-In the same way, Balder searches for scenarios, it will do that for Setups. These setups have to be in files that have
+In the same way, Balder searches for scenarios, it will do that for setups. These setups have to be in files that have
 the name ``setup_*.py` and whose classes have the name ``Setup*`` and are child classes of :class:`Setup`.
 
 .. note::
@@ -83,14 +83,14 @@ With the previous step, Balder has automatically loaded all defined testcase met
 testcases have to be defined as a method in a :ref:`Scenario <Scenarios>` class. The name of these test methods always
 has to start with ``test_ *``. A scenario could define as much test methods as you like.
 
-Collect Connections
+Collect connections
 -------------------
 
 :ref:`Connections` are objects that connects devices with each other. These objects will be included in a global
 connection tree, which is the general representation of usable Balder connections. In every project you can define your
 own connections within python modules/files with the name ``connections``. These files will be read by Balder
 automatically during the collecting process. They will be inserted into the
-:ref:`global Connection-Tree <The global connection tree>`.
+:ref:`global connection-tree <The global connection tree>`.
 
 Matching process of setups and scenarios (SOLVING)
 ==================================================
@@ -240,7 +240,7 @@ two elements do not go together..
 
 They need some :ref:`Features`!
 
-Devices with Features
+Devices with features
 =====================
 
 In the previous step all our devices doesn't have a real functionality, they only exist. For this Balder provides
@@ -248,7 +248,7 @@ In the previous step all our devices doesn't have a real functionality, they onl
 through the :ref:`Balder Intro Example` you have learned the basic functionality of features. For a full introduction
 to features, you can also discover the basic documentation section :ref:`Features`.
 
-Add Feature functionality
+Add feature functionality
 -------------------------
 
 So let us add some functionality to our scenario definition. For this we have to add some features. Get the rule back
@@ -302,7 +302,7 @@ the scenario can not be executed.
 Implement features in setup
 ---------------------------
 
-Of course we also need a feature implementation in our setups too. As you will see later, Features in
+Of course we also need a feature implementation in our setups too. As you will see later, features in
 :ref:`Scenario-Devices <Scenario-Device>` often only define the interface that is needed by the scenario-device, but we
 often do not provide a direct implementation of it there. Mostly the direct implementation is done on setup level.
 
@@ -484,14 +484,14 @@ of them. The following table shows them with the scope, they are valid.
 | ``balderglob.py`` file |                        | specific testset you are calling. This fixture will be executed in |
 |                        |                        | every test run.                                                    |
 +------------------------+------------------------+--------------------------------------------------------------------+
-| as method in           | only in this Setup     | This fixture runs only if this Setup will be executed in the       |
+| as method in           | only in this setup     | This fixture runs only if this setup will be executed in the       |
 | :class:`Setup`         |                        | current testrun. If the **execution-level** is ``session`` it will |
-|                        |                        | be executed as session-fixture only if this Setup is in the        |
+|                        |                        | be executed as session-fixture only if this setup is in the        |
 |                        |                        | executor tree. If the  **execution-level** is ``setup`` or lower,  |
 |                        |                        | this fixture will only be called if the setup is currently active  |
 |                        |                        | in the test run.                                                   |
 +------------------------+------------------------+--------------------------------------------------------------------+
-| as method in           | only in this Scenario  | This fixture runs only if this Scenario will be executed in the    |
+| as method in           | only in this scenario  | This fixture runs only if this scenario will be executed in the    |
 | :class:`Scenario`      |                        | current testrun. If the **execution-level** is ``session`` or      |
 |                        |                        | `setup` it will be executed as session-/ or setup-fixture only if  |
 |                        |                        | this Scenario is in the executor tree. If the  **execution-level** |

--- a/doc/source/basics/execution_mechanism.rst
+++ b/doc/source/basics/execution_mechanism.rst
@@ -342,7 +342,7 @@ In Balder, his looks like the following:
 
     class SetupBasic(balder.Setup):
 
-        class This(balder.Setup.This):
+        class This(balder.Device):
             server = SendGetRequestImplFeature()  # implements the `SendGetRequestFeature`
             ...
 
@@ -542,7 +542,7 @@ that you can interact with the setup-devices on this stage too.
 
     class SetupBasic(balder.Setup):
 
-        class This(balder.Setup.This):
+        class This(balder.Device):
             request = SendGetRequestImplFeature()
             ...
 

--- a/doc/source/basics/execution_mechanism.rst
+++ b/doc/source/basics/execution_mechanism.rst
@@ -7,15 +7,15 @@ Balder Execution mechanism
 
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
-After you start the execution in a balder project with the command line `balder ..`, balder will go through a procedure
-of tree steps. First balder collects all relevant items that can be found in the project directory (the current working
-directory) and imports their balder-related classes and functions. For this purpose balder keeps an internal overview
+After you start the execution in a Balder project with the command line `balder ..`, Balder will go through a procedure
+of tree steps. First Balder collects all relevant items that can be found in the project directory (the current working
+directory) and imports their Balder related classes and functions. For this purpose Balder keeps an internal overview
 of all :ref:`Setup <Setups>`, :ref:`Scenario <Scenarios>` and :ref:`Connection <Connections>` classes. With that
-information, balder will start to create possible matching between the collected setups and scenario instances. In this
-step, balder creates the whole execution tree that contains all existing matches with its device-mappings organized in
-an execution-tree. In the last step balder executes this tree with the inclusion of all :ref:`Features` and test cases.
+information, Balder will start to create possible matching between the collected setups and scenario instances. In this
+step, Balder creates the whole execution tree that contains all existing matches with its device-mappings organized in
+an execution-tree. In the last step Balder executes this tree with the inclusion of all :ref:`Features` and test cases.
 
-To make it easier to understand the functionality of balder, we will start to consider the differences between
+To make it easier to understand the functionality of Balder, we will start to consider the differences between
 :ref:`Setup <Setups>` classes and :ref:`Scenario <Scenarios>` classes a little bit more in detail.
 
 Difference between Setup and Scenario
@@ -56,8 +56,8 @@ in the execution step. You can read more about this in the further subsections o
 Collecting process
 ==================
 
-The collection process is the first stage of the balder execution mechanism, directly after executing the ``balder ...``
-command. In this stage all available relevant balder classes within the working directory are collected.
+The collection process is the first stage of the Balder execution mechanism, directly after executing the ``balder ...``
+command. In this stage all available relevant Balder classes within the working directory are collected.
 
 Collect Setups and Scenarios
 ----------------------------
@@ -67,10 +67,10 @@ collected in the earlier step.
 
 Balder searches for scenarios exclusively in files with the name ``scenario_*.py``. In these files it searches for
 classes, which are subclasses of the master :class:`Scenario` class and if their name starts with ``Scenario*``.
-Only for classes that meet all these criteria, balder will acknowledge these classes as valid scenarios and add
+Only for classes that meet all these criteria, Balder will acknowledge these classes as valid scenarios and add
 them to the internal collection of executable scenarios.
 
-In the same way, balder searches for scenarios, it will do that for Setups. These setups have to be in files that have
+In the same way, Balder searches for scenarios, it will do that for Setups. These setups have to be in files that have
 the name ``setup_*.py` and whose classes have the name ``Setup*`` and are child classes of :class:`Setup`.
 
 .. note::
@@ -79,7 +79,7 @@ the name ``setup_*.py` and whose classes have the name ``Setup*`` and are child 
 Collect tests
 -------------
 
-With the previous step, balder has automatically loaded all defined testcase methods too, because in balder all
+With the previous step, Balder has automatically loaded all defined testcase methods too, because in Balder all
 testcases have to be defined as a method in a :ref:`Scenario <Scenarios>` class. The name of these test methods always
 has to start with ``test_ *``. A scenario could define as much test methods as you like.
 
@@ -87,16 +87,16 @@ Collect Connections
 -------------------
 
 :ref:`Connections` are objects that connects devices with each other. These objects will be included in a global
-connection tree, which is the general representation of usable balder connections. In every project you can define your
-own connections within python modules/files with the name ``connections``. These files will be read by balder
+connection tree, which is the general representation of usable Balder connections. In every project you can define your
+own connections within python modules/files with the name ``connections``. These files will be read by Balder
 automatically during the collecting process. They will be inserted into the
 :ref:`global Connection-Tree <The global connection tree>`.
 
 Matching process of setups and scenarios (SOLVING)
 ==================================================
 
-After the collecting process, balder knows all existing setup and scenario classes. Now it is time to determine
-the matchings between them. For this balder checks if the definition of the :ref:`Scenario <Scenarios>` (defines what
+After the collecting process, Balder knows all existing setup and scenario classes. Now it is time to determine
+the matchings between them. For this Balder checks if the definition of the :ref:`Scenario <Scenarios>` (defines what
 we need) matches in one possible constellation of one or more :ref:`Setup(s) <Setups>` (defines what we have).
 
 What are variations?
@@ -104,7 +104,7 @@ What are variations?
 
 In the SOLVING stage, Balder determines so called variations. This describes the device mappings between all required
 :ref:`Scenario-Devices <Scenario-Device>` and their mapped :ref:`Setup-Device`. First all variations will be
-added, regardless of whether they are executable. In the first part of the SOLVING stage, balder will create a
+added, regardless of whether they are executable. In the first part of the SOLVING stage, Balder will create a
 variation for every possible device mapping first. If a mapping really fits (same feature and containing connection
 trees between all device mappings - later more) will be determined
 :ref:`in the second part of the SOLVING stage <SOLVING Part 2: Filtering Variations>`.
@@ -215,7 +215,7 @@ setup devices in ``Variation4`` or ``Variation6`` aren't connected with each oth
 to the ``This`` device, but not between each other. These variations simply doesn't make sense, because the devices
 have a complete different connection with each other.
 
-In view of this fact the ``Variation4`` or the ``Variation6`` can not be executed and will be filtered by balder. Balder
+In view of this fact the ``Variation4`` or the ``Variation6`` can not be executed and will be filtered by Balder. Balder
 now has 4 active variations that could be executed from the current point of view:
 
 .. code-block:: none
@@ -235,7 +235,7 @@ now has 4 active variations that could be executed from the current point of vie
 
 As you can see there are still some variations, we do not want to be executed. For example in the ``Variation3``
 our scenario device ``ClientDevice`` is mapped to the server device ``MyServerDevice1``, but this doesn't make
-sense, we want a client device here. But wait - how should balder know this? Only the name is an indication that these
+sense, we want a client device here. But wait - how should Balder know this? Only the name is an indication that these
 two elements do not go together..
 
 They need some :ref:`Features`!
@@ -243,7 +243,7 @@ They need some :ref:`Features`!
 Devices with Features
 =====================
 
-In the previous step all our devices doesn't have a real functionality, they only exist. For this balder provides
+In the previous step all our devices doesn't have a real functionality, they only exist. For this Balder provides
 :ref:`Features`. Features are classes that can be used by devices and offers functionality for these. If you have gone
 through the :ref:`Balder Intro Example` you have learned the basic functionality of features. For a full introduction
 to features, you can also discover the basic documentation section :ref:`Features`.
@@ -306,7 +306,7 @@ Of course we also need a feature implementation in our setups too. As you will s
 :ref:`Scenario-Devices <Scenario-Device>` often only define the interface that is needed by the scenario-device, but we
 often do not provide a direct implementation of it there. Mostly the direct implementation is done on setup level.
 
-To understand the balder execution mechanism it doesn't matter where the implementation is done. First of all, it is
+To understand the Balder execution mechanism it doesn't matter where the implementation is done. First of all, it is
 sufficient to know, that every ``*ImplFeature`` feature in our setup is a subclass of the defined feature classes in
 our ``ScenarioLogin``.
 Every of these setup features contains the implementation of all interface methods and properties that are defined in
@@ -333,7 +333,7 @@ For this, we expand our setup in the following way:
         This <--> MyServerDevice1: HttpConnection
         This <--> MyServerDevice2: HttpConnection
 
-In balder, his looks like the following:
+In Balder, his looks like the following:
 
 .. code-block:: python
 
@@ -357,7 +357,7 @@ In balder, his looks like the following:
             ...
 
 .. note::
-    The names of the class properties, the feature instances are assigned to, doesn't matter for balder. They are
+    The names of the class properties, the feature instances are assigned to, doesn't matter for Balder. They are
     only relevant, if you want to access the feature instance in the setup class itself (you will see later in
     :ref:`Using Fixtures`).
 
@@ -388,13 +388,13 @@ Get back in mind, that we had four of our six variations left:
         Scenario `ClientDevice` <=> Setup `MyServerDevice2`
         Scenario `ServerDevice` <=> Setup `This`
 
-These are already filtered after their connections, but balder hasn't check their feature implementation.
-For this balder will go through every possible variation and check it the mapped devices on the setup side uses child
+These are already filtered after their connections, but Balder hasn't check their feature implementation.
+For this Balder will go through every possible variation and check it the mapped devices on the setup side uses child
 classes of the feature that are defined in the corresponding scenario device. Only if every feature of every mapped
 scenario device has a relevant child implementation in the corresponding setup device, the variation is still
 applicable.
 
-In ``Variation1`` balder will start looking for the ``ClientDevice``. It will notices that it **needs** the
+In ``Variation1`` Balder will start looking for the ``ClientDevice``. It will notices that it **needs** the
 ``SendGetRequestFeature``. The ``This`` device on the other side is the mapped setup device for the ``ClientDevice``.
 For this variation matches, Balder has to secure, that this setup device implements all existing features (as child
 subclasses). With that, it iterates over the features of the setup device ``This``, and recognize the feature
@@ -474,7 +474,7 @@ executed or not also depends on the **definition-scope**.
 The definition-scope
 --------------------
 
-In balder there exists a lot of different **definition-scopes**. These scopes define to a certain extent the validity
+In Balder there exists a lot of different **definition-scopes**. These scopes define to a certain extent the validity
 of them. The following table shows them with the scope, they are valid.
 
 +------------------------+------------------------+--------------------------------------------------------------------+
@@ -518,13 +518,13 @@ This fixture can look like the following:
 
     @balder.fixture(level="session")
     def signal_balder_is_running():
-        # sets the information that balder is running now
+        # sets the information that Balder is running now
         notification.send("balder is running")
         yield
         notification.send("balder terminated")
 
 .. note::
-    Note that balder will collect only the ``balderglob.py`` file that is located directly in the working directory. If
+    Note that Balder will collect only the ``balderglob.py`` file that is located directly in the working directory. If
     you want to separate your global elements, you can distribute your code but you have to import it in the global
     ``balderglob.py`` file.
 

--- a/doc/source/basics/features.rst
+++ b/doc/source/basics/features.rst
@@ -117,8 +117,8 @@ The implementation of the ``ManagePipeFeature`` doesn't matter, but we want to u
             self.pipe.send(msg)
 
 You simply have to instantiate it as class attribute inside your feature. This will automatically lead to the behavior,
-that balder assumes that your feature only works with a device, that also provides an implementation for the
-``ManagePipeFeature``. The reference inside your feature will automatically provided by balder on variation-level.
+that Balder assumes that your feature only works with a device, that also provides an implementation for the
+``ManagePipeFeature``. The reference inside your feature will automatically provided by Balder on variation-level.
 
 Autonomous-Features
 ===================
@@ -193,7 +193,7 @@ setup:
 Bind Features
 =============
 
-A big advantage of balder is that you are able to reuse components. This also applies to features. But mostly you will
+A big advantage of Balder is that you are able to reuse components. This also applies to features. But mostly you will
 not use them under the exact same conditions. So maybe you want to use a ``SendFeature`` with a device that can only
 send messages over SMS while you also use this feature with a device that can only send its messages over tcp. So how we
 can handle this?
@@ -210,7 +210,7 @@ In addition to that, it is also possible to bind single methods of your feature 
 tree or/and for the usage with one VDevice only. This allows it to define a method multiple times with different
 `@for_vdevice` bindings. So for example you can implement a method `send` that will be used if the device (that is
 assigned as VDevice) is connected over a TcpConnection. And additionally to that you have another method `send` that is
-bind to a `UdpConnection`. Depending on the current Scenario/Setup, balder will use the correct method variation of
+bind to a `UdpConnection`. Depending on the current Scenario/Setup, Balder will use the correct method variation of
 `send`, after you call it in your testcase. This is the so called **method-based-binding**.
 
 This section describes how this mechanism generally works. You can find a lot of more detailed explanations in the
@@ -261,7 +261,7 @@ attribute ``OtherPipeVDevice="PipeDevice2"`` to the feature constructor to defin
 
 
 .. note::
-    Often you can not access the Device type objects inside the feature constructor. For this balder also allows to use
+    Often you can not access the Device type objects inside the feature constructor. For this Balder also allows to use
     simple strings, that contains the same name than the referencing device type.
 
 You can do this with different devices that could stand for different usages of this feature. So you can also add
@@ -430,7 +430,7 @@ defines, that the devices should be connected over an TcpConnection. If the test
 now uses on of our methods ``MyMessengerFeature.send(..)``, the variation with the decorator
 ``@balder.for_vdevice(..., over_connection=[TcpConnection])`` will be used.
 
-If one would exchange the connection with the ``SerialConnection``, balder would select the method variation with the
+If one would exchange the connection with the ``SerialConnection``, Balder would select the method variation with the
 decorator ``@balder.for_vdevice(MessengerFeature.OtherVDevice, with_connection=SerialConnection)``.
 
 .. note::

--- a/doc/source/basics/features.rst
+++ b/doc/source/basics/features.rst
@@ -24,7 +24,7 @@ To understand this more easily, let's take a look at the following example:
     class SenderFeature(balder.Feature):
 
         def send(msg):
-            raise NotImplementedError("this feature has to be implemented by feature class of Setup")
+            raise NotImplementedError("this feature has to be implemented by feature class of setup")
 
 
 .. code-block:: python
@@ -128,7 +128,7 @@ properties, they are only used to say:
 
 *This device has the feature ``IsRedFeature``*
 
-So we want to filter them, because we only want a match with a device that has the same Feature, but we can't or
+So we want to filter them, because we only want a match with a device that has the same feature, but we can't or
 don't want to influence or interact with this device over the autonomous :class:`.Feature`.
 
 The definition for such a autonomous feature, is really easy:
@@ -190,7 +190,7 @@ setup:
                 pass
 
 
-Bind Features
+Bind features
 =============
 
 A big advantage of Balder is that you are able to reuse components. This also applies to features. But mostly you will
@@ -207,10 +207,10 @@ to limit the allowed connections the feature is able to use with this :class:`VD
 This is the so called **class-based-binding**.
 
 In addition to that, it is also possible to bind single methods of your feature to a subset of the allowed sub-connection
-tree or/and for the usage with one VDevice only. This allows it to define a method multiple times with different
+tree or/and for the usage with one vDevice only. This allows it to define a method multiple times with different
 `@for_vdevice` bindings. So for example you can implement a method `send` that will be used if the device (that is
-assigned as VDevice) is connected over a TcpConnection. And additionally to that you have another method `send` that is
-bind to a `UdpConnection`. Depending on the current Scenario/Setup, Balder will use the correct method variation of
+assigned as vDevice) is connected over a TcpConnection. And additionally to that you have another method `send` that is
+bind to a `UdpConnection`. Depending on the current scenario/setup, Balder will use the correct method variation of
 `send`, after you call it in your testcase. This is the so called **method-based-binding**.
 
 This section describes how this mechanism generally works. You can find a lot of more detailed explanations in the
@@ -261,7 +261,7 @@ attribute ``OtherPipeVDevice="PipeDevice2"`` to the feature constructor to defin
 
 
 .. note::
-    Often you can not access the Device type objects inside the feature constructor. For this Balder also allows to use
+    Often you can not access the device type objects inside the feature constructor. For this Balder also allows to use
     simple strings, that contains the same name than the referencing device type.
 
 You can do this with different devices that could stand for different usages of this feature. So you can also add
@@ -294,7 +294,7 @@ way.
     Balder checks if the requirement that is given with the **Class-Based-Binding** is available. If the requirement
     doesn't match the class-based statement, it throws an error!
 
-How does that influence the Setup? - You are also able to define these vDevice-Device mapping in the setup. This is even
+How does that influence the setup? - You are also able to define these vDevice-Device mapping in the setup. This is even
 often the case, because your setup normally uses the specific functionality. Your scenario should be as universal as
 possible. You can also use this mechanism on scenario level. If you want to find out more about this, take a look at the
 :ref:`VDevices and method-variations` section.
@@ -305,7 +305,7 @@ Method-Based-Binding
 Often it is required to provide different implementations for different vDevices or different sub-connection-trees in a
 feature. For this you can use **Method-Based-Binding**.
 
-Let's assume, we have a Feature that could send a message to another device. For this case, the connection type
+Let's assume, we have a feature that could send a message to another device. For this case, the connection type
 does not really matter, because the feature should support this requirement generally for every possible connection.
 So it is only important to test that the device can send a message to another device. It does not matter, how the
 feature send this message (at least at scenario level).
@@ -335,15 +335,15 @@ Basically our scenario level implementation looks like:
 
 
 
-As you can see, we have defined the inner VDevice ``OtherVDevice`` here. We want to use the feature
+As you can see, we have defined the inner vDevice ``OtherVDevice`` here. We want to use the feature
 ``RecvMessengerFeature`` with this vDevice. For this we instantiate it as class property of the ``OtherVDevice``. This
 allows us, to define the requirement the mapped device should implement already in this feature.
 
 .. note::
-    The elements given in the inner VDevice class definition is a **MUST HAVE**, which means that the statement has to
+    The elements given in the inner vDevice class definition is a **MUST HAVE**, which means that the statement has to
     be available in the mapped device later, otherwise it would throw an error.
 
-Till now the Scenario-Feature doesn't use some **Method-Based-Bindings**. This will change in a few moments, when we
+Till now the scenario-feature doesn't use some **Method-Based-Bindings**. This will change in a few moments, when we
 implement the setup-level representation of this feature.
 
 Before we take action for the setup implementation, we want to create a :ref:`Scenario <Scenarios>` using this newly
@@ -375,7 +375,7 @@ created feature. For this, we want to implement a example scenario with two devi
             assert all_messages[0] == SEND_DATA, "have not received the sent data
 
 As you can see we have created a mapping for the inner :class:`VDevice` to an real defined scenario :class:`Device`
-by using the name of the inner VDevice as key and the name of the real device as value in the constructor. We also
+by using the name of the inner vDevice as key and the name of the real device as value in the constructor. We also
 implement a basic test, that should check the communication.
 
 So let's start to implement the setup level. We can implement our earlier defined feature by simply inheriting from it.

--- a/doc/source/basics/fixtures.rst
+++ b/doc/source/basics/fixtures.rst
@@ -217,17 +217,17 @@ The following table shows these scopes:
 | ``balderglob.py`` file |                        | specific testset is called. This fixture will be executed in       |
 |                        |                        | every test run.                                                    |
 +------------------------+------------------------+--------------------------------------------------------------------+
-| as method in           | only in this Setup     | This fixture runs only if the Setup (the fixture is defined in)    |
+| as method in           | only in this setup     | This fixture runs only if the setup (the fixture is defined in)    |
 |                        |                        | will be executed in the current testrun. If the                    |
 | :ref:`Setups`          |                        | **execution-level** is ``session`` it will be executed as          |
-|                        |                        | session-fixture only if this Setup is in the executor tree. If the |
+|                        |                        | session-fixture only if this setup is in the executor tree. If the |
 |                        |                        | **execution-level** is ``setup`` or lower, this fixture will only  |
 |                        |                        | be called if the setup is currently active in the test run.        |
 +------------------------+------------------------+--------------------------------------------------------------------+
-| as method in           | only in this Scenario  | This fixture runs only if the Scenario (the fixture is defined in) |
+| as method in           | only in this scenario  | This fixture runs only if the scenario (the fixture is defined in) |
 | :ref:`Scenarios`       |                        | will be executed in the current testrun. If the                    |
 |                        |                        | **execution-level** is ``session`` or `setup` it will be executed  |
-|                        |                        | as session-/ or setup-fixture only if this Scenario is in the      |
+|                        |                        | as session-/ or setup-fixture only if this scenario is in the      |
 |                        |                        | executor tree. If the  **execution-level** is ``scenario`` or      |
 |                        |                        | lower, this fixture will only be called if the scenario is         |
 |                        |                        | currently active in the test run.                                  |

--- a/doc/source/basics/fixtures.rst
+++ b/doc/source/basics/fixtures.rst
@@ -44,7 +44,7 @@ part of the fixture. The code behind will be executed after the branch ran itsel
 
 .. note::
 
-    You can also omit the ``yield`` command. But with this, balder assumes that no teardown code is available.
+    You can also omit the ``yield`` command. But with this, Balder assumes that no teardown code is available.
 
 Execution-Level
 ---------------
@@ -60,7 +60,7 @@ Definition-Scope
 ----------------
 
 The **definition-scope** describes the validity of the fixture. It depends on the definition position, the fixture is
-located in the balder testsystem. For example, if you implement a fixture in the global ``balderglob.py`` file, it has
+located in the Balder testsystem. For example, if you implement a fixture in the global ``balderglob.py`` file, it has
 the **definition-scope** GLOBAL. This means, that it is valid for the whole test session. It is valid for every testcase
 that is executed within a test session. If a fixture (that is defined in the ``balderglob.py`` file) has the decorator
 ``@balder.fixture(level="session")`` it will always be executed, independent of the :ref:`Scenario <Scenarios>` and
@@ -84,14 +84,14 @@ Fixture ordering
 
 Like you saw in the earlier sections, it is due to two important characteristics, when and how a fixture will be
 executed - the **execution-level**, which is defined at the fixture decorator and the **definition-scope**, which is
-defined over the location the fixture is placed in. But how does balder order the fixtures that are within the same
+defined over the location the fixture is placed in. But how does Balder order the fixtures that are within the same
 **execution-level**?
 
-First of all, balder creates a outer ordering by its **definition-scope**. Before the scenario-scoped-fixtures (defined
+First of all, Balder creates a outer ordering by its **definition-scope**. Before the scenario-scoped-fixtures (defined
 within a :class:`Scenario <Scenario>` class) will be executed, the setup-scoped-fixtures (defined in the
 :class:`Setup <Setup>` class) will run. Global-fixtures (defined in the global ``balderglob.py`` file) will be executed
 before them both. With this mechanism we have a basic ordering, but the order for fixture with the same
-**definition-scope** (and of course the same **execution-level**) is still undefined. For this balder provides the
+**definition-scope** (and of course the same **execution-level**) is still undefined. For this Balder provides the
 ability of chaining fixtures with each other.
 
 Take a look at the following example:
@@ -193,7 +193,7 @@ execution. The following table shows all possible **execution-level** attributes
 |                        | :ref:`Scenario <Scenarios>` changes. It embraces every new :class:`Setup <Setups>` class    |
 |                        | that will be get active in the test executor.                                               |
 +------------------------+---------------------------------------------------------------------------------------------+
-| ``variation``          | The **variation** in the balder test system is a new possible device assignment between the |
+| ``variation``          | The **variation** in the Balder test system is a new possible device assignment between the |
 |                        | :ref:`Scenario-Devices <Scenario-Device>` and the :ref:`Setup-Devices <Setup-Device>`.      |
 |                        | Depending on the **definition-scope** this fixture runs before and after every new device   |
 |                        | variation of its scoped :ref:`Setup <Setups>` / :ref:`Scenario <Scenarios>` constellation.  |
@@ -240,7 +240,7 @@ As mentioned above, Balder can referencing fixtures among each other.
 
 Sometimes you want to use the values of some fixtures into testcases or other fixtures. For example if you prepare an
 object in a fixture you maybe want to use this object in another fixture or in your testcase too. This can be
-realized in balder by simply referencing fixtures throw method/function attributes.
+realized in Balder by simply referencing fixtures throw method/function attributes.
 
 .. code-block:: py
 
@@ -383,7 +383,7 @@ reference them? For example if you define a fixture ``calc`` in your global ``ba
 :class:`Scenario` which has a fixture ``calc`` defined too. Now you want to reference `calc` within the test method of
 this scenario. Which value will be provided?
 
-First of all, every fixture will be called by balder. It won't matter if they have the same name. The name will only
+First of all, every fixture will be called by Balder. It won't matter if they have the same name. The name will only
 matter if you want to referencing these fixtures. Maybe it will be getting clearer if we take a look at the following
 example:
 
@@ -415,9 +415,9 @@ Now we have a fixture with the same name in our global ``balderglob.py`` file:
 
 Both fixtures have the same name ``calc`` and the same **execution-level**. First of all the **definition-scope**
 doesn't matter for the executed ordering of the fixtures as long as they are not referenced among each other. If you
-reference them, balder will be forced to adjust the order of them. However, the situation is different if you reference
+reference them, Balder will be forced to adjust the order of them. However, the situation is different if you reference
 these fixtures. If you have two fixtures with the same **execution-level** and with the same name, but different
-**definition-scopes**, balder will select them according their **definition-scope**.
+**definition-scopes**, Balder will select them according their **definition-scope**.
 
 For example, if you referencing the ``calc`` fixture from another fixture in the ``balderglob.py`` file, it
 will call the next higher one (related to the **definition-scope**):
@@ -498,7 +498,7 @@ Special case: Unclear-Setup_Scoped_Fixture-Reference problematic
 
 There is one single case, you should be aware with. If you want to reference a session-fixture
 with the **definition-scope** SETUP from a session-fixture with the **definition-level** SCENARIO. For this case it is
-not clear which setup balder should use, because no setup is active yet (we are still on SESSION level).
+not clear which setup Balder should use, because no setup is active yet (we are still on SESSION level).
 
 This should be avoided and not use. Balder will throw an exception :class:`UnclearSetupScopedFixtureReference` here!
 

--- a/doc/source/basics/fixtures.rst
+++ b/doc/source/basics/fixtures.rst
@@ -99,7 +99,7 @@ Take a look at the following example:
 
 .. code-block:: py
 
-    # file `balder.py`
+    # file `balderglob.py`
 
     @balder.fixture(level='session')
     def my_own_fixture1():
@@ -244,7 +244,7 @@ realized in Balder by simply referencing fixtures throw method/function attribut
 
 .. code-block:: py
 
-    # file `balder.py`
+    # file `balderglob.py`
 
     import balder
 
@@ -310,7 +310,7 @@ example:
 
 .. code-block:: py
 
-    # file `balder.py`
+    # file `balderglob.py`
 
     # BE CAREFUL: THIS EXAMPLE LEADS TO AN ERROR!
 

--- a/doc/source/basics/index.rst
+++ b/doc/source/basics/index.rst
@@ -8,7 +8,7 @@ before going deeper.
 The different subsections of this chapter are created independently from each other. So feel free to jump to the
 subsection you want to learn more about.
 
-If you want to get a deeper understanding how balder is implemented internally or if you have some specific questions
+If you want to get a deeper understanding how Balder is implemented internally or if you have some specific questions
 about some of these topics, please take a look at the `Reference Guides <../deeper>`_.
 
 .. toctree::

--- a/doc/source/basics/scenarios.rst
+++ b/doc/source/basics/scenarios.rst
@@ -11,10 +11,10 @@ A (test) scenario describes the environment that a test **needs** to be able to 
 :ref:`Setups` that describes what you **have**). A scenario allows to define a test environment first, after the
 individual test cases will be implemented.
 
-Create a Scenario
+Create a scenario
 =================
 
-Every Scenario class have to be located in a file that fulfils the naming ``scenario_*.py``. To keep it clear, it
+Every scenario class have to be located in a file that fulfils the naming ``scenario_*.py``. To keep it clear, it
 is often useful to create a own directory for the scenario which has the same name like the scenario python file. So you
 can define your related objects, you only use for your single scenario inside this directory.
 However Balder will load the python file (with naming ``scenario_*.py``) in its collecting process and searches for
@@ -69,12 +69,12 @@ You can also define some by your own.
 
 .. note::
     These connection objects are already in a relationship before you use them. They are included in a global
-    Connection-Tree. This tree defines a hierarchical structure of the connections (for example, that Ethernet can be
+    connection-tree. This tree defines a hierarchical structure of the connections (for example, that Ethernet can be
     transmitted over a ``CoaxialCableConnection`` or a ``OpticalFiberConnection``.
 
     It is also possible to expand this tree by your own or if necessary to use a complete custom tree.
 
-    You can read more about this :ref:`here <Connection-Trees>`.
+    You can read more about this :ref:`here <connection trees>`.
 
 In addition to define single connections, you can also select a part of the global connection tree or combine some
 connections with an OR or an AND relationship. So for example you could connect our devices and allow an Ethernet as
@@ -173,7 +173,7 @@ With that, we added two abstract methods without an implementation yet. We are g
 :class:`Feature` subclass of our :ref:`Setups` later.
 
 .. note::
-    In some cases it can be useful to provide a implementation in the Scenario-:class:`Feature` implementation too.
+    In some cases it can be useful to provide a implementation in the scenario-feature implementation too.
     You can find more details about that in the :ref:`Features section <Features>`.
 
 Use the features and write tests

--- a/doc/source/basics/scenarios.rst
+++ b/doc/source/basics/scenarios.rst
@@ -17,7 +17,7 @@ Create a Scenario
 Every Scenario class have to be located in a file that fulfils the naming ``scenario_*.py``. To keep it clear, it
 is often useful to create a own directory for the scenario which has the same name like the scenario python file. So you
 can define your related objects, you only use for your single scenario inside this directory.
-However balder will load the python file (with naming ``scenario_*.py``) in its collecting process and searches for
+However Balder will load the python file (with naming ``scenario_*.py``) in its collecting process and searches for
 classes that are a subclass of :class:`Scenario` and starts with the name `Scenario`.
 
 .. code-block:: py
@@ -30,7 +30,7 @@ classes that are a subclass of :class:`Scenario` and starts with the name `Scena
                 pass
 
 Get it back in your mind, **a scenario defines the things your test needs**. The most obvious is that you want to test
-something, usually a device or an object. For this balder provides :class:`Device` classes.
+something, usually a device or an object. For this Balder provides :class:`Device` classes.
 
 Add one or more devices
 =======================
@@ -180,7 +180,7 @@ Use the features and write tests
 ================================
 
 Now we can write our first test method. We want to send a Hello-World message and want to make sure that it was
-received successfully. It is important that the name of a test method always starts with ``test_*()``, otherwise balder
+received successfully. It is important that the name of a test method always starts with ``test_*()``, otherwise Balder
 will not collect it as a testcase.
 
 
@@ -215,7 +215,7 @@ execute our newly created properties and methods.
     Mark test to SKIP or IGNORE
     ===========================
 
-    Balder provides an easy integration to mark a test in the way to SKIP or IGNORE it from balder test system. This can be
+    Balder provides an easy integration to mark a test in the way to SKIP or IGNORE it from Balder test system. This can be
     done with the class attributes ``IGNORE``, ``SKIP`` and ``RUN``, which are part of every :class:`.Scenario` class. Per
     default the ``RUN`` attribute contains a list with all testcases that are mentioned in the :class:`.Scenario` and
     inherited tests that are still active in the higher classes.

--- a/doc/source/basics/setups.rst
+++ b/doc/source/basics/setups.rst
@@ -41,7 +41,7 @@ You can create a new :class:`Device` in your setup by simply defining a new inne
         ...
 
 
-Add other Device
+Add other device
 ----------------
 
 Feel free to create more devices. You should add all devices you want to use in your tests within this setup. Balder

--- a/doc/source/basics/vdevices.rst
+++ b/doc/source/basics/vdevices.rst
@@ -79,7 +79,7 @@ implements the functionality of the earlier example, but with vDevices:
 
         class Client(balder.Device):
             # we have to map the vDevice with our real device (use the class name of the vDevice as key and the
-            #  Device class you want to map as value)
+            #  device class you want to map as value)
             load = LoadSiteFeature(WebServerVDevice=ScenarioLoadWeb.Server)
 
         def test_load(self):
@@ -126,7 +126,7 @@ we can rework our feature class:
             # ???
             ...
 
-As you can see, we have three different VDevices in our feature implementation. Every vDevice works in another way:
+As you can see, we have three different vDevices in our feature implementation. Every vDevice works in another way:
 
 +----------------------------------+------------------------+----------------------------------------------------------+
 | Feature-VDevice                  | needs the features     | Description                                              |
@@ -164,7 +164,7 @@ If you use our feature in a scenario and add the following vDevice mapping:
 
         class Client(balder.Device):
             # we have to map the vDevice with our real device (for this use the class name of the vDevice and the
-            #  Device class we want to map)
+            #  device class we want to map)
             load = LoadSiteFeature(WebServerVDevice=ScenarioLoadWeb.Server)
 
         def test_check_title(self):
@@ -287,7 +287,7 @@ Nested method variation calls
 Often you want to call other methods from methods itself. You can freely do this. Balder will handle the correct calling
 of all methods in the feature, also for nested calls.
 
-Bind vDevice for Connection-Trees
+Bind vDevice for connection-trees
 =================================
 
 You can also narrow the method variations even further by specifying a specific connection tree in the

--- a/doc/source/basics/vdevices.rst
+++ b/doc/source/basics/vdevices.rst
@@ -40,7 +40,7 @@ vDevices
 
 A vDevice is a inner-feature device that describes a possible other device this feature interacts with. You simply
 create a vDevice, describe which features it should have (by instantiating them like it is done with normal devices) and
-use them. All other things will be automatically managed from balder.
+use them. All other things will be automatically managed from Balder.
 
 Let's go back to the example from earlier. Instead of giving the attribute as method parameters, you can create a
 vDevice that uses the ``HttpServerFeature``. This allows you to access the properties and methods of the
@@ -275,7 +275,7 @@ The example from before becomes much clearer if you use method variations:
     Sometimes python does not allow to reference the type variable for vDevices. You can use a string with the name of
     the vDevice here too. Balder will automatically resolve this internally.
 
-Depending on the current mapped vDevice balder automatically calls the method variation, that fits for the current
+Depending on the current mapped vDevice Balder automatically calls the method variation, that fits for the current
 active vDevice.
 
 .. note::
@@ -349,7 +349,7 @@ Our ``SendFeature`` class is implemented in the following way:
 As you can see it is also possible to define method variations depending on the current active connection tree. Even
 it is not clear which variation it will execute in scenario level, till now it does not matter over which connection
 the two devices are connected with each other. It is enough if the setup will restrict this later. If we specify that
-our setup only supports an ``EMailConnection`` for example, balder automatically knows which method variation should be
+our setup only supports an ``EMailConnection`` for example, Balder automatically knows which method variation should be
 called.
 
 What happens if we have multiple possibilities?
@@ -357,20 +357,20 @@ What happens if we have multiple possibilities?
 
 
 It is the responsibility of the feature developer that there exists exactly one clear variation for every possible
-vDevice and connection-tree constellation. For this balder will execute an initial check on the beginning of the
+vDevice and connection-tree constellation. For this Balder will execute an initial check on the beginning of the
 execution.
 
 Instead of illegally multiple method variations (multiple variations, with independent OR connections), hierarchically
 method variations are allowed. It is possible that you provide different implementations for different sizes of an
 connection-tree. If you have one method variation with a connection tree ``Tcp.based_on(Ethernet)`` and one with a
 single ``Ethernet``, of course you want to use the method variation with the bigger tree (the
-``Tcp.based_on(Ethernet)``). Theoretically, however, the small one would also fit. Here balder first tries to sort these
+``Tcp.based_on(Ethernet)``). Theoretically, however, the small one would also fit. Here Balder first tries to sort these
 trees hierarchically and check if one of them is CONTAINED-IN another. Balder allows the execution and selects the
 biggest one if, this hierarchical structure works for all method-variation candidates of a variation.
 
 It will secure that for every possible constellation only one method variation is implemented or that all possibilities
 of the method variation connection-tree are CONTAINED-IN each other. Otherwise it will run in an error in the collecting
-stage of balder. It would be not possible to execute the test session with that.
+stage of Balder. It would be not possible to execute the test session with that.
 
 Use multi-vDevice feature multiple times
 ========================================
@@ -381,7 +381,7 @@ Use multi-vDevice feature multiple times
 ..
     .. todo
 
-Maybe you wondered if you can use a feature multiple times. Normally balder does not support this, because it is
+Maybe you wondered if you can use a feature multiple times. Normally Balder does not support this, because it is
 not defined which scenario-feature should be replaced with which setup-feature. But there is one useful
 possibility to define features multiple times. Map different vDevices on it.
 
@@ -432,7 +432,7 @@ and on scenario level. The setup implementation could look like the following ex
         class RecvDevice2(balder.Device):
             recv = RecvFeature()
 
-As you can see in the example above, you only have to secure that balder exactly knows which feature instance it should
+As you can see in the example above, you only have to secure that Balder exactly knows which feature instance it should
 use for which device. With this it is possible to instantiate the same features multiple times.
 
 Class based for_vdevice
@@ -483,5 +483,5 @@ corresponding devices later. It always describes the merged data of the method v
 
 .. note::
     If you define a class based decorator which is a smaller set than the possibilities defined with method variations,
-    balder will reduce the method variation set to the defined class based decoration here! In this case, balder will
+    balder will reduce the method variation set to the defined class based decoration here! In this case, Balder will
     throw a warning.

--- a/doc/source/deeper/connections.rst
+++ b/doc/source/deeper/connections.rst
@@ -8,6 +8,6 @@ Deeper look into Connections
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
 Connections are a important component of the Balder ecosystem. Your connection statements can assume different states.
-This sections help to understand how the connection mechanism is implemented inside balder.
+This sections help to understand how the connection mechanism is implemented inside Balder.
 
 

--- a/doc/source/deeper/connections.rst
+++ b/doc/source/deeper/connections.rst
@@ -1,4 +1,4 @@
-Deeper look into Connections
+Deeper look into connections
 ****************************
 
 .. important::

--- a/doc/source/deeper/index.rst
+++ b/doc/source/deeper/index.rst
@@ -2,7 +2,7 @@ Reference Guides
 ****************
 
 These documentation section contains technical references to understand the implementation and the exact functionality
-of balder. These sections assume that you have a basic understanding of the key concepts described in
+of Balder. These sections assume that you have a basic understanding of the key concepts described in
 :ref:`Basic Guides<Basic Guides>`.
 
 .. toctree::

--- a/doc/source/deeper/metadata_management.rst
+++ b/doc/source/deeper/metadata_management.rst
@@ -7,4 +7,4 @@ Metadata management
 
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
-Balder uses a lot of inner hidden class properties that manages the workflow of balder. This section describes them.
+Balder uses a lot of inner hidden class properties that manages the workflow of Balder. This section describes them.

--- a/doc/source/deeper/process.rst
+++ b/doc/source/deeper/process.rst
@@ -7,4 +7,4 @@ Balder process
 
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
-This section describes the process how balder executes a test session and which steps it passes during it.
+This section describes the process how Balder executes a test session and which steps it passes during it.

--- a/doc/source/getting_started/balder_components.rst
+++ b/doc/source/getting_started/balder_components.rst
@@ -1,9 +1,9 @@
 Main Balder components
 **********************
 
-The following section should help getting an overview over the available components in balder. You will learn the key
+The following section should help getting an overview over the available components in Balder. You will learn the key
 facts about :ref:`Scenarios` and :ref:`Setups` and how their :ref:`Devices` work. You will learn what
-:ref:`Features` are and how balder matches these between :ref:`Scenarios` and :ref:`Setups`. You will also learn how to
+:ref:`Features` are and how Balder matches these between :ref:`Scenarios` and :ref:`Setups`. You will also learn how to
 connect devices with each other over :ref:`Connections` and how :ref:`Connection-Trees` are defined.
 
 Note that this section only provides an overview of the components. You can find a detailed description of each
@@ -36,7 +36,7 @@ Setup: Describes what you have
 It is different when we look at the :ref:`Setups`. In a setup you define everything that is available and
 relevant in the environment, the particular setup is for. So for example, if you have your computer, the router and the
 server of company X in your influenceable spectrum of devices you can add all of them to your setup. Also if the
-scenario is written later only for the router and the server, it will work out, because balder will automatically match
+scenario is written later only for the router and the server, it will work out, because Balder will automatically match
 scenario-devices with compatible setup-devices.
 
 What are devices?
@@ -189,10 +189,10 @@ provides the specific setup level features:
 
     Here you can implement many files in it, which allows you to separate the features a little bit.
 
-How does balder know, which feature you are implementing?
+How does Balder know, which feature you are implementing?
 ---------------------------------------------------------
 
-Maybe you ask yourself how balder knows which scenario-feature you are implementing in your setup. For this balder
+Maybe you ask yourself how Balder knows which scenario-feature you are implementing in your setup. For this Balder
 uses **Inheritance**!
 
 The scenario-features often implement abstract properties or methods. You can implement them easily by overwriting them.
@@ -237,9 +237,9 @@ like it is done in the scenario, but of course with the subclass, that really pr
     Please note, that :class:`Setup` classes must be defined inside files that start with `setup_*.py`. In
     addition their class name has to start with `Setup*`. Otherwise the file will not be picked up by Balder.
 
-You can implement more devices than in the scenario, balder doesn't care. It will search for devices that match the
+You can implement more devices than in the scenario, Balder doesn't care. It will search for devices that match the
 **requirement**, defined in scenario. If the matching candidates have a matching connection-tree and if all required
-features of a scenario-device are also implemented in the setup-device, balder will run the scenario-testcases with this
+features of a scenario-device are also implemented in the setup-device, Balder will run the scenario-testcases with this
 constellation!
 
 .. note::
@@ -255,7 +255,7 @@ between scenarios and setups are:
 
 **Setup:** Describes what you have
 
-These are the golden rules, balder works with. After you have defined a scenario, add some devices to it and instantiate
+These are the golden rules, Balder works with. After you have defined a scenario, add some devices to it and instantiate
 their feature objects as their class attributes. This describes what your testcase needs.
 
 Then you think about **what you have**. How does your test rack or your test pc/pipeline look like? All this can be
@@ -267,12 +267,12 @@ Matching process
 
 When Balder is executed and after it has collected all relevant classes, the matching process takes place. It
 determines which device-mappings (between scenarios and setups) match with each other. For
-that, Balder is interested in the feature sets your devices have. Based on these feature sets, balder will automatically
+that, Balder is interested in the feature sets your devices have. Based on these feature sets, Balder will automatically
 determine the possible mappings between the :ref:`Scenario <Scenarios>`-Devices and the
 :ref:`Setup <Setups>`-Devices.
 
 Generally, Balder will create matching candidates by searching possible mappings of a scenario device with one of
-the available setup devices. In this stage balder does not care if the devices are compatible.
+the available setup devices. In this stage Balder does not care if the devices are compatible.
 
 Feature check
 -------------
@@ -345,7 +345,7 @@ the matching devices. Every matching with one or more device-connection that doe
 Execution
 =========
 
-In the last step balder will execute the mappings. You can execute balder, by simply calling it inside the project
+In the last step Balder will execute the mappings. You can execute Balder, by simply calling it inside the project
 directory:
 
 .. code-block:: none

--- a/doc/source/getting_started/balder_components.rst
+++ b/doc/source/getting_started/balder_components.rst
@@ -4,12 +4,12 @@ Main Balder components
 The following section should help getting an overview over the available components in Balder. You will learn the key
 facts about :ref:`Scenarios` and :ref:`Setups` and how their :ref:`Devices` work. You will learn what
 :ref:`Features` are and how Balder matches these between :ref:`Scenarios` and :ref:`Setups`. You will also learn how to
-connect devices with each other over :ref:`Connections` and how :ref:`Connection-Trees` are defined.
+connect devices with each other over :ref:`Connections` and how :ref:`connection trees` are defined.
 
 Note that this section only provides an overview of the components. You can find a detailed description of each
 element in the :ref:`Basic Guide <Basic Guides>`.
 
-Difference Setup and Scenario
+Difference setup and scenario
 =============================
 
 The basis of Balder is based on individual scenarios and setups that are in a fixed relationship to each other.
@@ -92,7 +92,7 @@ In the real world, devices are connected with each other. If you have a **Browse
 mentioned before, you could expect that these are connected with each other over something like a HTTP connection. For
 this, Balder provides :ref:`Connections`.
 
-Simple Connections
+Simple connections
 ------------------
 
 Balder is shipped with a lot of different connections (see :ref:`Connections API`). In addition, you can create your
@@ -105,10 +105,10 @@ own ones, by simply inheriting from the master class :class:`Connection`.
     class MyOwnConnection(Connection):
         pass
 
-Connection-Trees
+Connection trees
 ----------------
 
-The Connection-Tree is a global hierarchical structure, that describes how connections are arranged with each other. For
+The connection-tree is a global hierarchical structure, that describes how connections are arranged with each other. For
 example that a ``HttpConnection`` is based on a ``TcpConnection`` which itself is based on ``IpV4Connection`` or
 ``IpV6Connection``.
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -1,11 +1,11 @@
 Getting Started
 ***************
 
-This is the basic getting started section. It provides the basics on how the balder framework works. We recommend
+This is the basic getting started section. It provides the basics on how the Balder framework works. We recommend
 to go through this section, before going deeper into the :ref:`Basic Guides<Basic Guides>` or
 :ref:`Reference Guides<Reference Guides>`. The Getting Started part of the documentation helps to understand the key
-concepts of balder in a short time. With it, you can directly start to write your own test scenarios or use one of the
-available balderhub projects and create your own setups for it.
+concepts of Balder in a short time. With it, you can directly start to write your own test scenarios or use one of the
+`available BalderHub projects <https://hub.balder.dev>`_ and create your own setups for it.
 
 .. toctree::
     :maxdepth: 2

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ************
 
-Before you can start to develop with balder, you will need to install it.
+Before you can start to develop with Balder, you will need to install it.
 
 Install python
 ==============
@@ -10,10 +10,10 @@ For this python in the version ``3.9`` or higher is required. You can get the la
 `https://www.python.org/downloads/ <https://www.python.org/downloads/>`_ or install it with your packet management
 system of your operating system.
 
-Install balder
+Install Balder
 ==============
 
-You can easily install balder in different ways, that are described here.
+You can easily install Balder in different ways, that are described here.
 
 Install the official release
 ----------------------------
@@ -35,7 +35,7 @@ Install the latest developer version
    this will create a new directory ``balder`` in the current working directory
 3. Then run the command ``python -m pip install -e balder``
 
-This will make the code of balder importable and allows you to develop with the latest state of this branch.
+This will make the code of Balder importable and allows you to develop with the latest state of this branch.
 
 If you want to update your further installed developer version to the latest version, simply pull
 the changes with:

--- a/doc/source/getting_started/what_is_rsbt.rst
+++ b/doc/source/getting_started/what_is_rsbt.rst
@@ -112,7 +112,7 @@ This allows us to separate the test code from the application code. With these e
 ``Developer`` interacts with the ``CoffeeMachine``. We only want that the ``Developer`` starts the ``CoffeeMachine``
 without the knowledge how this is executed. Real specific code doesn't need to be implemented.
 
-How could such a Scenario look like? The following code shows how this test scenario would be implemented with Balder:
+How could such a scenario look like? The following code shows how this test scenario would be implemented with Balder:
 
 .. code-block:: python
 
@@ -145,7 +145,7 @@ How could such a Scenario look like? The following code shows how this test scen
 
 .. note::
     In a real implementation we would assign a mapping between some vDevices and the given devices here. But for now
-    we ignore that. You can read more about VDevices at :ref:`VDevices and method-variations`.
+    we ignore that. You can read more about vDevices at :ref:`VDevices and method-variations`.
 
 Here you can't see exactly how the machine was started. It could have been started from an app or by pressing the
 button on the coffee machine. This information is not necessary here, because at scenario level we only define

--- a/doc/source/getting_started/what_is_rsbt.rst
+++ b/doc/source/getting_started/what_is_rsbt.rst
@@ -190,5 +190,5 @@ code and make testing easier for others or use scenarios from other community me
 Learn more about
 ================
 
-This documentation shows you an insight how this concept is implemented in balder. Feel free to do the
+This documentation shows you an insight how this concept is implemented in Balder. Feel free to do the
 :ref:`tutorial <Tutorial Guide>` to learn the key concepts of Balder.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -47,17 +47,17 @@ different **Setups**:
 
 Balder was created especially for that. You can write one **Scenario** and use it for different setups.
 
-You can find out more about Scenario-Based-Testing and how balder works in this documentation.
+You can find out more about Scenario-Based-Testing and how Balder works in this documentation.
 
 If you are completely new, we recommend to start with the :ref:`Getting Started <Getting Started>` section. Since, in
 our opinion, the best way is learning-by-doing. We recommend to continue with the :ref:`Tutorial Guide`. If
-you want to discover all components of balder you can continue with the :ref:`Basic Guides<Basic Guides>`. All profound
-functions of balder, like the different internal work processes, you can find in the
+you want to discover all components of Balder you can continue with the :ref:`Basic Guides<Basic Guides>`. All profound
+functions of Balder, like the different internal work processes, you can find in the
 :ref:`Reference Guides<Reference Guides>`.
 
 It is recommended to go throw the different subsections of the :ref:`Getting Started <Getting Started>` and the
 :ref:`Tutorial Guide` in the provided order to fully understand the basic functionality of **Scenario-based-testing**
-and how it works in the balder framework. The different subsections of :ref:`Basic Guides<Basic Guides>` and
+and how it works in the Balder framework. The different subsections of :ref:`Basic Guides<Basic Guides>` and
 :ref:`Reference Guides<Reference Guides>` are created independently from each other. So feel free to jump to the
 subsection you want to learn more about. But we always recommend to start with the complete
 :ref:`Getting Started <Getting Started>` section before going deeper into the :ref:`Basic Guides<Basic Guides>` and

--- a/doc/source/tutorial_guide/00_intro.rst
+++ b/doc/source/tutorial_guide/00_intro.rst
@@ -141,18 +141,18 @@ command:
     Never use this package in an real environment. It uses the Django developer server that is only for developing and
     not secure to use in a productive environment.
 
-Prepare balder
+Prepare Balder
 ==============
 
-Now it's time to prepare our balder environment. For this, we create a sub folder ``tests`` into our project.
+Now it's time to prepare our Balder environment. For this, we create a sub folder ``tests`` into our project.
 
 .. note::
 
-    For an easier development we integrate our balder project inside the main project directory. In the most cases, it
+    For an easier development we integrate our Balder project inside the main project directory. In the most cases, it
     doesn't make sense to do it this way, because we want to do the test for multiple environments. For an easier
     workflow in this example here, however, we create a directory ``tests`` directly in the project.
 
-First of all, we have to create a new balder environment in our project. For this we create a new balder-project
+First of all, we have to create a new Balder environment in our project. For this we create a new Balder project
 in our ``tests`` directory. We will create the following directory structure:
 
 .. code-block:: none

--- a/doc/source/tutorial_guide/01_create_scenario.rst
+++ b/doc/source/tutorial_guide/01_create_scenario.rst
@@ -1,4 +1,4 @@
-Part 1: Develop a Scenario
+Part 1: Develop a scenario
 **************************
 
 First of all we have to think about the test scenarios we want to create for such a login app. There are a lot of
@@ -87,7 +87,7 @@ So we add these two devices. We call them ``ServerDevice`` and ``ClientDevice``.
         def test_valid_login_logout(self):
             pass
 
-The device classes are always inner-classes of the Scenario class, that uses the devices. In addition, they must inherit
+The device classes are always inner-classes of the scenario class, that uses the devices. In addition, they must inherit
 from :class:`balder.Device`.
 
 Connect the devices

--- a/doc/source/tutorial_guide/01_create_scenario.rst
+++ b/doc/source/tutorial_guide/01_create_scenario.rst
@@ -31,7 +31,7 @@ Create the new scenario
 -----------------------
 
 First of all we create a new file in our scenario submodule ``tests/scenarios/scenario_simple_loginout.py``. It is
-required, that the file name starts with ``scenario_*``, because balder only collects this files while it searches for
+required, that the file name starts with ``scenario_*``, because Balder only collects this files while it searches for
 scenario files.
 
 In this newly created file, we have to create a new :class:`Scenario` class:
@@ -434,7 +434,7 @@ However, it is still possible to provide some implementations in certain scenari
 we make our methods abstract by adding ``NotImplementedError`` everywhere.
 
 .. note::
-    If you are writing ``balderhub`` projects or if you are creating common scenarios that are used from other people
+    If you are writing BalderHub projects or if you are creating common scenarios that are used from other people
     it is highly recommended to add nice comments of all the classes and methods. In addition to that it is highly
     recommended to use type definitions. This makes the code more readable and nice structured. If you take a look in
     the example of this code in the

--- a/doc/source/tutorial_guide/02_single_setup.rst
+++ b/doc/source/tutorial_guide/02_single_setup.rst
@@ -199,7 +199,7 @@ We want to connect the two devices exactly in the same way as in the scenario. S
             credentials = MyInsertCredentialsFeature()
             internal = MyViewInternalPageFeature()
 
-As you can see, the devices directly inherit from the basic balder device and not from the scenario device.
+As you can see, the devices directly inherit from the basic Balder device and not from the scenario device.
 Balder manage this automatically. Balder doesn't really care for the device class, because it only exchange the
 features of it, but does not change the device itself.
 
@@ -273,7 +273,7 @@ Implement the Setup-Features
 ============================
 
 Now let us implement the different features we have already imported. Open the file ``setups/features.py`` and add the
-basic code. Secure that you inherit from the parent classes of the scenario level. With inheritance balder secures that
+basic code. Secure that you inherit from the parent classes of the scenario level. With inheritance Balder secures that
 a feature belongs to another. We also add the abstract methods, we have defined earlier that are filled with an
 ``NotImplementedError``. We will provide the full implementation of our methods there later:
 
@@ -449,7 +449,7 @@ give the same class name to the child vDevice class:
 .. note::
     Note that it is really important, that the child VDevice class has the same name that is given in the parent feature
     class! Otherwise the child VDevice will be interpreted as a new VDevice! In this case this will produce an exception
-    because balder only allows the redefining of inner devices by overwriting them all on one class level.
+    because Balder only allows the redefining of inner devices by overwriting them all on one class level.
 
 In a few moments, we will create a new feature class ``InternalWebpageFeature`` that should return some constant values
 about the server (for example the webpage url). This feature should be implemented by our real Server Device. We can
@@ -733,7 +733,7 @@ in the `single-setup branch on GitHub <https://github.com/balder-dev/balderexamp
             credentials = setup_features.MyInsertCredentialsFeature()
             internal = setup_features.MyViewInternalPageFeature()
 
-Execute balder
+Execute Balder
 ==============
 
 Now is the time to execute Balder and take advantage of the benefits it provides. We have a single setup, as well as a
@@ -767,7 +767,7 @@ Let's take a look how Balder will resolve our project without really executing i
 
 Great, the mapping works. Balder finds the valid variation.
 
-Now it is time to really run the balder session.
+Now it is time to really run the Balder session.
 
 .. note::
     Do not forget to start the django server before:
@@ -776,7 +776,7 @@ Now it is time to really run the balder session.
 
         $ python manage.py runserver
 
-After you have secured that the django server will be executed, you can start balder with the command:
+After you have secured that the django server will be executed, you can start Balder with the command:
 
 .. code-block::
 

--- a/doc/source/tutorial_guide/02_single_setup.rst
+++ b/doc/source/tutorial_guide/02_single_setup.rst
@@ -1,4 +1,4 @@
-Part 2: Implement Browser Setup
+Part 2: Implement browser setup
 *******************************
 
 Before we start to implement our first setup, let's take a look to the login-page. If you
@@ -58,7 +58,7 @@ We can now create the initial setup class in our newly created file:
         pass
 
 We want to create a setup, that matches with our scenario, we have created in
-:ref:`part 1 <Part 1: Develop a Scenario>`. In our scenario we defined two devices we need for the execution. These two
+:ref:`part 1 <Part 1: Develop a scenario>`. In our scenario we defined two devices we need for the execution. These two
 devices are needed in our setup too.
 
 Think about devices
@@ -70,7 +70,7 @@ with a scenario device if it implements at least all features (by inheriting fro
 .. note::
     This also means that a setup can have devices or features that are not mentioned in the scenario.
 
-So, according to our developed scenario we have developed in :ref:`part 1 <Part 1: Develop a Scenario>`, we need two
+So, according to our developed scenario we have developed in :ref:`part 1 <Part 1: Develop a scenario>`, we need two
 devices that implements the following features:
 
 ``MechanizeClient``:
@@ -101,7 +101,7 @@ scenario-device-connections have to BE IN the related connections of the setup d
 
 If you want to learn more about, how Balder works, check out the :ref:`Balder Execution mechanism`.
 
-Autonomous Feature
+Autonomous feature
 ------------------
 
 The autonomous feature ``HasLoginSystemFeature`` is a feature that doesn't contain some functional code, it simply
@@ -111,7 +111,7 @@ implementation, we can simply add it to every device that has this feature.
 
 You can find more about autonomous features :ref:`here <Autonomous-Features>`.
 
-Abstract Features
+Abstract features
 -----------------
 
 Most of the features we have implemented so far are abstract and have no implementation or at least have no complete
@@ -140,7 +140,7 @@ This newly created file ``features.py`` should contain our specific feature impl
 login.
 
 .. note::
-    In :ref:`Part 3: Expand Setup Code` we will expand this and use real hierarchy structured setup-feature code,
+    In :ref:`Part 3: Expand setup code` we will expand this and use real hierarchy structured setup-feature code,
     but for now this is quite sufficient.
 
 .. note::
@@ -150,7 +150,7 @@ login.
 Add the devices
 ---------------
 
-In the same way we have developed our scenario in :ref:`part 1 <Part 1: Develop a Scenario>`, we add the features
+In the same way we have developed our scenario in :ref:`part 1 <Part 1: Develop a scenario>`, we add the features
 before we really implement it. For an easier understanding, we use a simple name format for the features we will
 overwrite in our setup area. Every of these features will be named like ``My<scenario-feature-name>``.
 
@@ -227,9 +227,9 @@ the following:
 
 In the ``InsertCredentialsFeature`` constructor, that is used by the ``ClientDevice`` we have defined a mapping between
 our vDevice ``Server`` and our real device ``ServerDevice``. With this, we tell Balder that we want to use the
-``Server`` VDevice and that our real device ``ServerDevice`` should be mapped to it, thus representing it.
+``Server`` vDevice and that our real device ``ServerDevice`` should be mapped to it, thus representing it.
 
-By instantiating own features inside the VDevice, we define, that Balder should ensure that our mapped device (in our
+By instantiating own features inside the vDevice, we define, that Balder should ensure that our mapped device (in our
 case ``ServerDevice``) also provides an implementation for them.
 
 You can see this definition also inside the feature ``InsertCredentialsFeature``:
@@ -260,7 +260,7 @@ another device that provides this interface.
     from a peer device inside a feature.
 
 
-This VDevice-Device mapping also affects our setup, but we don't have to define the mapping again in the setup. It will
+This vDevice-Device mapping also affects our setup, but we don't have to define the mapping again in the setup. It will
 automatically secured by the device mapping algorithm.
 
 .. note::
@@ -269,7 +269,7 @@ automatically secured by the device mapping algorithm.
 This vDevice mechanism is very powerful. You are also able to define different methods for different mapped vDevices. If
 you want to find out more about that, check the section :ref:`VDevices and method-variations`.
 
-Implement the Setup-Features
+Implement the setup-features
 ============================
 
 Now let us implement the different features we have already imported. Open the file ``setups/features.py`` and add the
@@ -284,12 +284,12 @@ a feature belongs to another. We also add the abstract methods, we have defined 
         ValidRegisteredUserFeature
 
 
-    # Server Features
+    # Server features
     class MyValidRegisteredUserFeature(ValidRegisteredUserFeature):
         def get_valid_user(self):
             pass
 
-    # Client Features
+    # Client features
 
     class MyInsertCredentialsFeature(InsertCredentialsFeature):
 
@@ -323,7 +323,7 @@ later. You can add features to a vDevice by overwriting the inner class with the
 inheriting from the next parent. This is done here for the features ``MyInsertCredentialsFeature`` and
 ``MyViewInternalPageFeature``.
 
-Client Feature
+Client feature
 --------------
 
 We want to start with the method ``MyValidRegisteredUserFeature.get_user()``. This method should return a tuple with the
@@ -422,7 +422,7 @@ class property in the features that want to use it. For example, this can look l
 This allows you to simply refer it from your methods. It also defines that every device that uses the feature
 `MyViewInternalPageFeature` (by defining it as static attribute), has also implement the `BrowserSessionManagerFeature`.
 
-Implement the client Setup-Features
+Implement the client setup-features
 -----------------------------------
 
 As you may remember the setup features ``MyInsertCredentialsFeature`` and ``MyViewInternalPageFeature`` (which we still
@@ -447,13 +447,13 @@ give the same class name to the child vDevice class:
         browser_manager = BrowserSessionManagerFeature()
 
 .. note::
-    Note that it is really important, that the child VDevice class has the same name that is given in the parent feature
-    class! Otherwise the child VDevice will be interpreted as a new VDevice! In this case this will produce an exception
+    Note that it is really important, that the child vDevice class has the same name that is given in the parent feature
+    class! Otherwise the child vDevice will be interpreted as a new vDevice! In this case this will produce an exception
     because Balder only allows the redefining of inner devices by overwriting them all on one class level.
 
 In a few moments, we will create a new feature class ``InternalWebpageFeature`` that should return some constant values
-about the server (for example the webpage url). This feature should be implemented by our real Server Device. We can
-ensure this on feature level, by adding this feature to our VDevice ``Server``:
+about the server (for example the webpage url). This feature should be implemented by our real server device. We can
+ensure this on feature level, by adding this feature to our vDevice ``Server``:
 
 .. code-block:: python
 
@@ -464,9 +464,9 @@ ensure this on feature level, by adding this feature to our VDevice ``Server``:
 
         browser_manager = BrowserSessionManagerFeature()
 
-Just as we have already done with normal devices, we can address our feature in the VDevice, by using its property. So
+Just as we have already done with normal devices, we can address our feature in the vDevice, by using its property. So
 let us add an implementation for our abstract method ``ViewInternalPageFeature.check_internal_page_viewable()`` by
-using our new VDevice-Feature:
+using our new vDevice-Feature:
 
 .. code-block:: python
 
@@ -578,7 +578,7 @@ We have created some new features that we need specially for this setup, the ``L
 
     Before a variation (fixed mapping between scenario and setup devices) will be executed, Balder automatically
     exchanges all objects with the original objects that were instantiated in the setup. Everywhere! In all inner
-    feature references (also feature properties that are other instantiated Features), scenarios, vDevices and so on.
+    feature references (also feature properties that are other instantiated features), scenarios, vDevices and so on.
 
 Update our setup
 ----------------
@@ -623,7 +623,7 @@ in the `single-setup branch on GitHub <https://github.com/balder-dev/balderexamp
         ValidRegisteredUserFeature
 
 
-    # Server Features
+    # Server features
     class MyValidRegisteredUserFeature(ValidRegisteredUserFeature):
         def get_valid_user(self):
             return "guest", "guest12345"
@@ -661,7 +661,7 @@ in the `single-setup branch on GitHub <https://github.com/balder-dev/balderexamp
             return "http://localhost:8000/accounts/logout"
 
 
-    # Client Features
+    # Client features
 
     class MyInsertCredentialsFeature(InsertCredentialsFeature):
         class Server(InsertCredentialsFeature.Server):

--- a/doc/source/tutorial_guide/03_double_setup.rst
+++ b/doc/source/tutorial_guide/03_double_setup.rst
@@ -1,4 +1,4 @@
-Part 3: Expand Setup Code
+Part 3: Expand setup code
 *************************
 
 In this part we are going to learn one of the key concepts of Balder - reusing tests.
@@ -24,7 +24,7 @@ So let's go back to our example and restructure our earlier created project a li
 Prepare for the new setup
 =========================
 
-In :ref:`part 2 <Part 2: Implement Browser Setup>` we have already implemented a setup for our login server, that uses
+In :ref:`part 2 <Part 2: Implement browser setup>` we have already implemented a setup for our login server, that uses
 the web frontend to login to our internal page. Often we also need an API/REST interface to connect with internal
 components. Our loginserver also supports this. We want to add a new setup for this method now.
 
@@ -33,7 +33,7 @@ First of all, think about the features we need for it.
 Think about the devices
 -----------------------
 
-Similar to :ref:`part 2 <Part 2: Implement Browser Setup>` we could think about the required features we need for our
+Similar to :ref:`part 2 <Part 2: Implement browser setup>` we could think about the required features we need for our
 new setup class. If we go back to the scenario definition we need the following features:
 
 ``Loginserver``:
@@ -48,7 +48,7 @@ new setup class. If we go back to the scenario definition we need the following 
 
 As you can see we need the same features like we have used earlier in our first setup. Of course we need the same one,
 because we still have the same procedure. Similar to the webpage login, we need the procedure defined in
-:ref:`part 1 <Part 1: Develop a Scenario>`:
+:ref:`part 1 <Part 1: Develop a scenario>`:
 
 * check that we have no access to the internal page/data
 * insert a valid username
@@ -192,7 +192,7 @@ should look like the following:
                 |- __init__.py
                 |- setup_features.py
 
-Similar to :ref:`part 2 <Part 2: Implement Browser Setup>` we first define our new setup with the devices and all
+Similar to :ref:`part 2 <Part 2: Implement browser setup>` we first define our new setup with the devices and all
 imported features. Again we want to create two devices, one server devices that provides the rest api and one rest
 client device, that executes the requests with the basic authentication.
 
@@ -262,7 +262,7 @@ We have added two features that requires a own REST specific implementation. Let
             pass
 
 As you can see, we have also overwritten the vDevice instances, because we will need them in this features too.
-Similar to the :ref:`part 2 <Part 2: Implement Browser Setup>` we need a common feature that provides access to our api
+Similar to the :ref:`part 2 <Part 2: Implement browser setup>` we need a common feature that provides access to our api
 endpoint. Even though we don't really have a login area here, but actually send the access data with each request, we
 want to set up the whole thing similarly.
 

--- a/doc/source/tutorial_guide/03_double_setup.rst
+++ b/doc/source/tutorial_guide/03_double_setup.rst
@@ -1,7 +1,7 @@
 Part 3: Expand Setup Code
 *************************
 
-In this part we are going to learn one of the key concepts of balder - reusing tests.
+In this part we are going to learn one of the key concepts of Balder - reusing tests.
 
 This essential concept allows you to effortlessly utilize existing scenarios for various setups. Many projects require
 similar testing in multiple ways, whether it's supporting a user interface on different platforms or managing a device
@@ -425,12 +425,12 @@ Of course we have to add our new helper features in our REST setup too:
             internal = rest_features.MyViewInternalPageFeature()
 
 
-We have made it! We have implemented both setups and manage the common use of feature classes. So let's start balder.
+We have made it! We have implemented both setups and manage the common use of feature classes. So let's start Balder.
 
-Execute balder with both setups
+Execute Balder with both setups
 ===============================
 
-We can check if balder resolves our scenario with the both setups correctly. For this, just call balder with the
+We can check if Balder resolves our scenario with the both setups correctly. For this, just call Balder with the
 argument ``--resolve-only``:
 
 .. code-block::
@@ -461,7 +461,7 @@ argument ``--resolve-only``:
 Great, it works. Balder can find our two possible variations, one using our ``SetupWebBrowser`` and one using our
 ``SetupRestBasicAuth``.
 
-Now it is time to really run the balder session.
+Now it is time to really run the Balder session.
 
 .. note::
     Do not forget to start the django server before:
@@ -470,7 +470,7 @@ Now it is time to really run the balder session.
 
         $ python manage.py runserver
 
-After you have secured that the django server runs, you can run balder:
+After you have secured that the django server runs, you can run Balder:
 
 .. code-block::
 

--- a/doc/source/tutorial_guide/06_develop_with_connection_trees.rst
+++ b/doc/source/tutorial_guide/06_develop_with_connection_trees.rst
@@ -1,4 +1,4 @@
-Part 6: Develop with Connection-Trees
+Part 6: Develop with connection-trees
 *************************************
 
 .. warning::

--- a/doc/source/tutorial_guide/07_convert_in_balderhub.rst
+++ b/doc/source/tutorial_guide/07_convert_in_balderhub.rst
@@ -3,7 +3,7 @@ Develop and use BalderHub project
 
 .. warning::
    This section is currently under development and will be released shortly!
-   If you are interested into developing new balderhub project, feel free to take a look into
+   If you are interested into developing new BalderHub project, feel free to take a look into
    :ref:`BalderHub - the share place of tests`.
 
 ..

--- a/doc/source/tutorial_guide/index.rst
+++ b/doc/source/tutorial_guide/index.rst
@@ -2,7 +2,7 @@ Tutorial Guide
 **************
 
 We think, that the easiest way to learn is learning-by-doing. For this, the following example will introduce you to the
-most important components of the balder system, by creating Balder tests for an example project which you can find in
+most important components of the Balder system, by creating Balder tests for an example project which you can find in
 many projects and companies.
 
 But before you start, make sure that you have read the `Getting Started Guide <Getting Started>`_, because this guide


### PR DESCRIPTION
This PR fixes some snippets in the documentation and ensures spelling of `Balder` and `BalderHub`. In addition it ensures that `device`, `vDevice`, `feature`, `scenario`, `setup` & `connection` are written in the same format