### PR TITLE
`variation_executor.can_be_applied()` now uses exception instead of return value

### DIFF
--- a/src/_balder/exceptions.py
+++ b/src/_balder/exceptions.py
@@ -158,7 +158,7 @@ class IllegalVDeviceMappingError(BalderException):
     """
 
 
-class NotApplicableVariationError(BalderException):
+class NotApplicableVariationException(BalderException):
     """
     is thrown internally after the current variation is not applicable
     """

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -12,7 +12,7 @@ from _balder.previous_executor_mark import PreviousExecutorMark
 from _balder.routing_path import RoutingPath
 from _balder.unmapped_vdevice import UnmappedVDevice
 from _balder.controllers import DeviceController, VDeviceController, FeatureController, NormalScenarioSetupController
-from _balder.exceptions import NotApplicableVariationError, UnclearAssignableFeatureConnectionError
+from _balder.exceptions import NotApplicableVariationException, UnclearAssignableFeatureConnectionError
 
 if TYPE_CHECKING:
     from _balder.setup import Setup
@@ -235,7 +235,7 @@ class VariationExecutor(BasicExecutor):
                             cleanup_replacing_features.remove(cur_replacing_feature)
 
                 if len(cleanup_replacing_features) != 1:
-                    raise NotApplicableVariationError(
+                    raise NotApplicableVariationException(
                         f'this variation can not be applicable because there was no setup feature implementation of '
                         f'`{cur_abstract_scenario_feature_obj.__class__.__name__}` (used by scenario device '
                         f'`{cur_scenario_device.__name__}`) in setup device `{cur_setup_device.__name__}`')
@@ -254,7 +254,7 @@ class VariationExecutor(BasicExecutor):
                             f"`{cur_abstract_scenario_feature_obj.__class__.__name__}` (used in scenario device "
                             f"`{cur_scenario_device.__name__}` and in setup device `{cur_setup_device.__name__}`) - "
                             f"VARIATION CAN NOT BE APPLIED")
-                        raise NotApplicableVariationError(
+                        raise NotApplicableVariationException(
                             f'this variation can not be applicable because there was no vDevice mapping given on '
                             f'scenario or on setup level for the feature '
                             f'`{cur_abstract_scenario_feature_obj.__class__.__name__}` (used by scenario device '
@@ -648,7 +648,7 @@ class VariationExecutor(BasicExecutor):
                 return False
             if not self.has_all_valid_routings():
                 return False
-        except NotApplicableVariationError:
+        except NotApplicableVariationException:
             # this variation can not be used, because the features can not be resolved correctly!
             return False
 
@@ -698,7 +698,7 @@ class VariationExecutor(BasicExecutor):
                 cur_mapped_setup_device = list(mapping_dict.values())[0]
 
                 if cur_mapped_setup_device not in self.base_device_mapping.values():
-                    raise NotApplicableVariationError(
+                    raise NotApplicableVariationException(
                         f'the mapped setup device `{cur_mapped_setup_device.__qualname__}` which is mapped to the '
                         f'VDevice `{cur_setup_feature_vdevice.__qualname__}` is no part of this variation')
 

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -248,6 +248,22 @@ class VariationExecutor(BasicExecutor):
                             f' for required feature `{cur_vdevice_feature.__class__}` of vDevice '
                             f'`{mapped_setup_vdevices[0].__qualname__}`')
 
+    def _verify_applicability_trough_all_valid_routings(self) -> None:
+        """
+        This method ensures that valid routings exist for every defined connection.
+
+        The check is passed, if the method finds one or more valid routings for EVERY scenario-level
+        :class:`Connection`.
+        """
+        if not self._routings:
+            self.determine_absolute_scenario_device_connections()
+            self.create_all_valid_routings()
+        for scenario_cnn, cur_routings in self._routings.items():
+            if len(cur_routings) == 0:
+                raise NotApplicableVariationException(
+                    f'can not find a valid routing on setup level for the connection `{scenario_cnn.get_tree_str()}` '
+                    f'between scenario devices `{scenario_cnn.from_device}` and `{scenario_cnn.to_device}`')
+
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
     def add_testcase_executor(self, testcase_executor: TestcaseExecutor):
@@ -442,22 +458,6 @@ class VariationExecutor(BasicExecutor):
         This method implementation of the :class:`VariationExecutor` does nothing.
         """
 
-    def has_all_valid_routings(self) -> None:
-        """
-        This method ensures that valid routings exist for every defined connection.
-
-        The check is passed, if the method finds one or more valid routings for EVERY scenario-level
-        :class:`Connection`.
-        """
-        if not self._routings:
-            self.determine_absolute_scenario_device_connections()
-            self.create_all_valid_routings()
-        for scenario_cnn, cur_routings in self._routings.items():
-            if len(cur_routings) == 0:
-                raise NotApplicableVariationException(
-                    f'can not find a valid routing on setup level for the connection `{scenario_cnn.get_tree_str()}` '
-                    f'between scenario devices `{scenario_cnn.from_device}` and `{scenario_cnn.to_device}`')
-
     def update_scenario_device_feature_instances(self):
         """
         This method ensures that the (mostly abstract) feature instances of a scenario are exchanged with the
@@ -651,7 +651,7 @@ class VariationExecutor(BasicExecutor):
 
             self._verify_applicability_trough_vdevice_feature_impl_matching()
 
-            self.has_all_valid_routings()
+            self._verify_applicability_trough_all_valid_routings()
         except NotApplicableVariationException:
             # this variation can not be used, because the features can not be resolved correctly!
             return False

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -442,21 +442,21 @@ class VariationExecutor(BasicExecutor):
         This method implementation of the :class:`VariationExecutor` does nothing.
         """
 
-    def has_all_valid_routings(self) -> bool:
+    def has_all_valid_routings(self) -> None:
         """
-        This method returns true if there exist valid routings for every defined connection. Otherwise, it returns
-        false.
+        This method ensures that valid routings exist for every defined connection.
 
-        :return: returns true if the method finds one or more valid routings for EVERY :class:`Connection`. Otherwise,
-                 it returns false
+        The check is passed, if the method finds one or more valid routings for EVERY scenario-level
+        :class:`Connection`.
         """
         if not self._routings:
             self.determine_absolute_scenario_device_connections()
             self.create_all_valid_routings()
-        for _, cur_routings in self._routings.items():
+        for scenario_cnn, cur_routings in self._routings.items():
             if len(cur_routings) == 0:
-                return False
-        return True
+                raise NotApplicableVariationException(
+                    f'can not find a valid routing on setup level for the connection `{scenario_cnn.get_tree_str()}` '
+                    f'between scenario devices `{scenario_cnn.from_device}` and `{scenario_cnn.to_device}`')
 
     def update_scenario_device_feature_instances(self):
         """
@@ -651,8 +651,7 @@ class VariationExecutor(BasicExecutor):
 
             self._verify_applicability_trough_vdevice_feature_impl_matching()
 
-            if not self.has_all_valid_routings():
-                return False
+            self.has_all_valid_routings()
         except NotApplicableVariationException:
             # this variation can not be used, because the features can not be resolved correctly!
             return False

--- a/src/balder/exceptions.py
+++ b/src/balder/exceptions.py
@@ -5,7 +5,7 @@ from _balder.exceptions import FixtureScopeError, FixtureReferenceError, Unclear
     AccessToUnmappedVDeviceException, FeatureOverwritingError, UnknownVDeviceException, RoutingBrokenChainError, \
     IllegalConnectionTypeError, ConnectionMetadataConflictError, DeviceScopeError, ConnectionIntersectionError, \
     UnclearAssignableFeatureConnectionError, InheritanceError, MultiInheritanceError, InnerFeatureResolvingError, \
-    VDeviceResolvingError, IllegalVDeviceMappingError, NotApplicableVariationError, UnclearMethodVariationError, \
+    VDeviceResolvingError, IllegalVDeviceMappingError, NotApplicableVariationException, UnclearMethodVariationError, \
     UnexpectedPluginMethodReturnValue
 
 __all__ = [
@@ -37,7 +37,7 @@ __all__ = [
     "InnerFeatureResolvingError",
     "VDeviceResolvingError",
     "IllegalVDeviceMappingError",
-    "NotApplicableVariationError",
+    "NotApplicableVariationException",
     "UnclearMethodVariationError",
     "UnexpectedPluginMethodReturnValue",
 ]


### PR DESCRIPTION
This PR updates the implementation of `variation_executor.can_be_applied()`. It prepares the environment for the coming argument `--show-discarded`, that should display information about discarded variations. 

This PR only changes the mechanism to exceptions (with message information) instead of boolean return statements (that do not hold any information why the variation was discarded).