### PR TITLE
refactor properties `*_executors` to methods `get_*_executors()`

### DIFF
--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -101,7 +101,7 @@ class ExecutorTree(BasicExecutor):
         all_testcase_executor = []
         for cur_scenario_executor in self.get_all_scenario_executors():
             for cur_variation_executor in cur_scenario_executor.get_variation_executors():
-                all_testcase_executor += cur_variation_executor.testcase_executors
+                all_testcase_executor += cur_variation_executor.get_testcase_executors()
         return all_testcase_executor
 
     def add_setup_executor(self, setup_executor: SetupExecutor):
@@ -184,5 +184,5 @@ class ExecutorTree(BasicExecutor):
                     max_len = max(len(cur_elem) for cur_elem in mapping_printings.keys())
                     for cur_key, cur_val in mapping_printings.items():
                         print(("{:<" + str(max_len) + "} = {}").format(cur_key, cur_val))
-                    for cur_testcase_excutor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_excutor in cur_variation_executor.get_testcase_executors():
                         print(f"   -> Testcase<{cur_testcase_excutor.base_testcase_callable.__qualname__}>")

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -91,7 +91,7 @@ class ExecutorTree(BasicExecutor):
         """
         all_variation_executor = []
         for cur_scenario_executor in self.get_all_scenario_executors():
-            all_variation_executor += cur_scenario_executor.variation_executors
+            all_variation_executor += cur_scenario_executor.get_variation_executors()
         return all_variation_executor
 
     def get_all_testcase_executors(self) -> List[TestcaseExecutor]:
@@ -100,7 +100,7 @@ class ExecutorTree(BasicExecutor):
         """
         all_testcase_executor = []
         for cur_scenario_executor in self.get_all_scenario_executors():
-            for cur_variation_executor in cur_scenario_executor.variation_executors:
+            for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                 all_testcase_executor += cur_variation_executor.testcase_executors
         return all_testcase_executor
 
@@ -175,7 +175,7 @@ class ExecutorTree(BasicExecutor):
         print("RESOLVING OVERVIEW", end="\n\n")
         for cur_setup_executor in self.get_setup_executors():
             for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     print(f"Scenario `{cur_scenario_executor.base_scenario_class.__class__.__qualname__}` <-> "
                           f"Setup `{cur_setup_executor.base_setup_class.__class__.__qualname__}`")
                     mapping_printings = {}

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -82,7 +82,7 @@ class ExecutorTree(BasicExecutor):
         """
         all_scenario_executor = []
         for cur_setup_executor in self.get_setup_executors():
-            all_scenario_executor += cur_setup_executor.scenario_executors
+            all_scenario_executor += cur_setup_executor.get_scenario_executors()
         return all_scenario_executor
 
     def get_all_variation_executors(self) -> List[VariationExecutor]:
@@ -132,7 +132,7 @@ class ExecutorTree(BasicExecutor):
         to_remove_executor = []
         for cur_setup_executor in self.get_setup_executors():
             cur_setup_executor.cleanup_empty_executor_branches()
-            if len(cur_setup_executor.scenario_executors) == 0:
+            if len(cur_setup_executor.get_scenario_executors()) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_setup_executor)
         for cur_setup_executor in to_remove_executor:
@@ -174,7 +174,7 @@ class ExecutorTree(BasicExecutor):
         """this method is an auxiliary method which outputs the entire tree"""
         print("RESOLVING OVERVIEW", end="\n\n")
         for cur_setup_executor in self.get_setup_executors():
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 for cur_variation_executor in cur_scenario_executor.variation_executors:
                     print(f"Scenario `{cur_scenario_executor.base_scenario_class.__class__.__qualname__}` <-> "
                           f"Setup `{cur_setup_executor.base_setup_class.__class__.__qualname__}`")

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -35,17 +35,12 @@ class ExecutorTree(BasicExecutor):
 
     @property
     def all_child_executors(self) -> List[BasicExecutor]:
-        return self.setup_executors
+        return self._setup_executors
 
     @property
     def base_instance(self) -> object:
         """returns None because this element is a ExecutorTree"""
         return None
-
-    @property
-    def setup_executors(self) -> List[SetupExecutor]:
-        """returns all setup executors of this tree"""
-        return self._setup_executors
 
     @property
     def fixture_manager(self) -> FixtureManager:
@@ -62,7 +57,7 @@ class ExecutorTree(BasicExecutor):
         pass
 
     def _body_execution(self):
-        for cur_setup_executor in self.setup_executors:
+        for cur_setup_executor in self.get_setup_executors():
             if cur_setup_executor.has_runnable_elements():
                 cur_setup_executor.execute()
             elif cur_setup_executor.prev_mark == PreviousExecutorMark.SKIP:
@@ -77,12 +72,16 @@ class ExecutorTree(BasicExecutor):
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
+    def get_setup_executors(self) -> List[SetupExecutor]:
+        """returns all setup executors of this tree"""
+        return self._setup_executors
+
     def get_all_scenario_executors(self) -> List[ScenarioExecutor]:
         """
         returns a list with all scenario executors
         """
         all_scenario_executor = []
-        for cur_setup_executor in self.setup_executors:
+        for cur_setup_executor in self.get_setup_executors():
             all_scenario_executor += cur_setup_executor.scenario_executors
         return all_scenario_executor
 
@@ -131,7 +130,7 @@ class ExecutorTree(BasicExecutor):
 
     def cleanup_empty_executor_branches(self):
         to_remove_executor = []
-        for cur_setup_executor in self.setup_executors:
+        for cur_setup_executor in self.get_setup_executors():
             cur_setup_executor.cleanup_empty_executor_branches()
             if len(cur_setup_executor.scenario_executors) == 0:
                 # remove this whole executor because it has no children anymore
@@ -154,7 +153,7 @@ class ExecutorTree(BasicExecutor):
 
         print_line(start_text)
         # check if there exists runnable elements
-        runnables = [cur_exec.has_runnable_elements() for cur_exec in self.setup_executors]
+        runnables = [cur_exec.has_runnable_elements() for cur_exec in self.get_setup_executors()]
         one_or_more_runnable_setups = None if len(runnables) == 0 else max(runnables)
         if one_or_more_runnable_setups:
             super().execute()
@@ -174,7 +173,7 @@ class ExecutorTree(BasicExecutor):
     def print_tree(self) -> None:
         """this method is an auxiliary method which outputs the entire tree"""
         print("RESOLVING OVERVIEW", end="\n\n")
-        for cur_setup_executor in self.setup_executors:
+        for cur_setup_executor in self.get_setup_executors():
             for cur_scenario_executor in cur_setup_executor.scenario_executors:
                 for cur_variation_executor in cur_scenario_executor.variation_executors:
                     print(f"Scenario `{cur_scenario_executor.base_scenario_class.__class__.__qualname__}` <-> "

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -46,7 +46,7 @@ class ScenarioExecutor(BasicExecutor):
 
     @property
     def all_child_executors(self) -> List[VariationExecutor]:
-        return self.variation_executors
+        return self._variation_executors
 
     @property
     def parent_executor(self) -> SetupExecutor:
@@ -63,11 +63,6 @@ class ScenarioExecutor(BasicExecutor):
     def base_scenario_class(self) -> Scenario:
         """returns the :class:`Scenario` class that belongs to this executor"""
         return self._base_scenario_class
-
-    @property
-    def variation_executors(self) -> List[VariationExecutor]:
-        """returns all variation executors that are child executor of this scenario executor"""
-        return self._variation_executors
 
     @property
     def fixture_manager(self) -> FixtureManager:
@@ -95,7 +90,7 @@ class ScenarioExecutor(BasicExecutor):
         print(f"  SCENARIO {self.base_scenario_class.__class__.__name__}")
 
     def _body_execution(self):
-        for cur_variation_executor in self.variation_executors:
+        for cur_variation_executor in self.get_variation_executors():
             if cur_variation_executor.has_runnable_elements():
                 cur_variation_executor.execute()
             elif cur_variation_executor.prev_mark == PreviousExecutorMark.SKIP:
@@ -110,12 +105,16 @@ class ScenarioExecutor(BasicExecutor):
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
+    def get_variation_executors(self) -> List[VariationExecutor]:
+        """returns all variation executors that are child executor of this scenario executor"""
+        return self._variation_executors
+
     def cleanup_empty_executor_branches(self):
         """
         This method removes all sub executors that are empty and not relevant anymore.
         """
         to_remove_executor = []
-        for cur_variation_executor in self.variation_executors:
+        for cur_variation_executor in self.get_variation_executors():
             if len(cur_variation_executor.testcase_executors) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_variation_executor)

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -115,7 +115,7 @@ class ScenarioExecutor(BasicExecutor):
         """
         to_remove_executor = []
         for cur_variation_executor in self.get_variation_executors():
-            if len(cur_variation_executor.testcase_executors) == 0:
+            if len(cur_variation_executor.get_testcase_executors()) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_variation_executor)
         for cur_variation_executor in to_remove_executor:

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -92,7 +92,7 @@ class SetupExecutor(BasicExecutor):
         to_remove_executor = []
         for cur_scenario_executor in self.get_scenario_executors():
             cur_scenario_executor.cleanup_empty_executor_branches()
-            if len(cur_scenario_executor.variation_executors) == 0:
+            if len(cur_scenario_executor.get_variation_executors()) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_scenario_executor)
         for cur_scenario_executor in to_remove_executor:

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -42,7 +42,7 @@ class SetupExecutor(BasicExecutor):
 
     @property
     def all_child_executors(self) -> List[ScenarioExecutor]:
-        return self.scenario_executors
+        return self._scenario_executors
 
     @property
     def parent_executor(self) -> ExecutorTree:
@@ -59,11 +59,6 @@ class SetupExecutor(BasicExecutor):
         return self._base_setup_class
 
     @property
-    def scenario_executors(self) -> List[ScenarioExecutor]:
-        """returns a list with all scenario executors that belongs to this setup executor"""
-        return self._scenario_executors
-
-    @property
     def fixture_manager(self) -> FixtureManager:
         """returns the current active fixture manager for this executor"""
         return self._fixture_manager
@@ -74,7 +69,7 @@ class SetupExecutor(BasicExecutor):
         print(f"SETUP {self.base_setup_class.__class__.__name__}")
 
     def _body_execution(self):
-        for cur_scenario_executor in self.scenario_executors:
+        for cur_scenario_executor in self.get_scenario_executors():
             if cur_scenario_executor.has_runnable_elements():
                 cur_scenario_executor.execute()
             elif cur_scenario_executor.prev_mark == PreviousExecutorMark.SKIP:
@@ -89,9 +84,13 @@ class SetupExecutor(BasicExecutor):
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
+    def get_scenario_executors(self) -> List[ScenarioExecutor]:
+        """returns a list with all scenario executors that belongs to this setup executor"""
+        return self._scenario_executors
+
     def cleanup_empty_executor_branches(self):
         to_remove_executor = []
-        for cur_scenario_executor in self.scenario_executors:
+        for cur_scenario_executor in self.get_scenario_executors():
             cur_scenario_executor.cleanup_empty_executor_branches()
             if len(cur_scenario_executor.variation_executors) == 0:
                 # remove this whole executor because it has no children anymore

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -102,11 +102,6 @@ class VariationExecutor(BasicExecutor):
 
     @property
     def all_child_executors(self) -> List[TestcaseExecutor]:
-        return self.testcase_executors
-
-    @property
-    def testcase_executors(self) -> List[TestcaseExecutor]:
-        """returns all sub testcase executors that belongs to this variation-executor"""
         return self._testcase_executors
 
     @property
@@ -147,7 +142,7 @@ class VariationExecutor(BasicExecutor):
         self.set_conn_dependent_methods()
 
     def _body_execution(self):
-        for cur_testcase_executor in self.testcase_executors:
+        for cur_testcase_executor in self.get_testcase_executors():
             if cur_testcase_executor.has_runnable_elements():
 
                 cur_testcase_executor.execute()
@@ -265,6 +260,10 @@ class VariationExecutor(BasicExecutor):
                     f'between scenario devices `{scenario_cnn.from_device}` and `{scenario_cnn.to_device}`')
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
+
+    def get_testcase_executors(self) -> List[TestcaseExecutor]:
+        """returns all sub testcase executors that belongs to this variation-executor"""
+        return self._testcase_executors
 
     def add_testcase_executor(self, testcase_executor: TestcaseExecutor):
         """

--- a/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
+++ b/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
@@ -121,7 +121,7 @@ class Test01EnvtesterMethvar(Base01EnvtesterMethvarClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
+++ b/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
@@ -113,7 +113,7 @@ class Test01EnvtesterMethvar(Base01EnvtesterMethvarClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
+++ b/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
@@ -129,7 +129,7 @@ class Test01EnvtesterMethvar(Base01EnvtesterMethvarClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
+++ b/tests/basic/test_01_envtester_methvar/test_01_envtester_methvar.py
@@ -137,7 +137,7 @@ class Test01EnvtesterMethvar(Base01EnvtesterMethvarClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/basic/test_0_envtester/test_0_envtester.py
+++ b/tests/basic/test_0_envtester/test_0_envtester.py
@@ -335,7 +335,7 @@ class Test0Envtester(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/basic/test_0_envtester/test_0_envtester.py
+++ b/tests/basic/test_0_envtester/test_0_envtester.py
@@ -343,7 +343,7 @@ class Test0Envtester(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/basic/test_0_envtester/test_0_envtester.py
+++ b/tests/basic/test_0_envtester/test_0_envtester.py
@@ -327,7 +327,7 @@ class Test0Envtester(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/basic/test_0_envtester/test_0_envtester.py
+++ b/tests/basic/test_0_envtester/test_0_envtester.py
@@ -319,7 +319,7 @@ class Test0Envtester(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
+++ b/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
@@ -151,7 +151,7 @@ class Test0InheritScenario(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
+++ b/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
@@ -159,7 +159,7 @@ class Test0InheritScenario(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
+++ b/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
@@ -135,7 +135,7 @@ class Test0InheritScenario(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
+++ b/tests/collecting/test_0_inherit_scenario/test_0_inherit_scenario.py
@@ -143,7 +143,7 @@ class Test0InheritScenario(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
+++ b/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
@@ -344,7 +344,7 @@ class Test0ConnectedOverStrReference(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
+++ b/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
@@ -352,7 +352,7 @@ class Test0ConnectedOverStrReference(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
+++ b/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
@@ -336,7 +336,7 @@ class Test0ConnectedOverStrReference(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
+++ b/tests/connection/test_0_connected_over_str_reference/test_0_connected_over_str_reference.py
@@ -360,7 +360,7 @@ class Test0ConnectedOverStrReference(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/connection/test_1_reverse_connect_3_scen_4_setup_devs/test_1_reverse_connect_3_scen_4_setup_devs.py
+++ b/tests/connection/test_1_reverse_connect_3_scen_4_setup_devs/test_1_reverse_connect_3_scen_4_setup_devs.py
@@ -27,7 +27,7 @@ def processed(env_dir):
         "test session does not terminates with success"
     assert len(session.executor_tree.get_setup_executors()) == 1, \
         "found not exactly one setup executor"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()) == 1, \
         "found not exactly one scenario executor"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 6, \
+    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()[0].variation_executors) == 6, \
         "found not exactly three variation executor"

--- a/tests/connection/test_1_reverse_connect_3_scen_4_setup_devs/test_1_reverse_connect_3_scen_4_setup_devs.py
+++ b/tests/connection/test_1_reverse_connect_3_scen_4_setup_devs/test_1_reverse_connect_3_scen_4_setup_devs.py
@@ -25,9 +25,9 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "found not exactly one setup executor"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
         "found not exactly one scenario executor"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors) == 6, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 6, \
         "found not exactly three variation executor"

--- a/tests/connection/test_1_reverse_connect_3_scen_4_setup_devs/test_1_reverse_connect_3_scen_4_setup_devs.py
+++ b/tests/connection/test_1_reverse_connect_3_scen_4_setup_devs/test_1_reverse_connect_3_scen_4_setup_devs.py
@@ -27,7 +27,10 @@ def processed(env_dir):
         "test session does not terminates with success"
     assert len(session.executor_tree.get_setup_executors()) == 1, \
         "found not exactly one setup executor"
-    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()) == 1, \
+
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
+
+    assert len(scenario_executors) == 1, \
         "found not exactly one scenario executor"
-    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()[0].variation_executors) == 6, \
+    assert len(scenario_executors[0].get_variation_executors()) == 6, \
         "found not exactly three variation executor"

--- a/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
+++ b/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
@@ -159,7 +159,7 @@ class Test0NewSetupOnlyDeviceFeature(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
+++ b/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
@@ -167,7 +167,7 @@ class Test0NewSetupOnlyDeviceFeature(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
+++ b/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
@@ -151,7 +151,7 @@ class Test0NewSetupOnlyDeviceFeature(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
+++ b/tests/device/test_0_new_setup_only_device_feature/test_0_new_setup_only_device_feature.py
@@ -175,7 +175,7 @@ class Test0NewSetupOnlyDeviceFeature(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
@@ -183,7 +183,7 @@ class Test0TreecheckFixtBalderglobScenarioConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
@@ -159,7 +159,7 @@ class Test0TreecheckFixtBalderglobScenarioConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
@@ -167,7 +167,7 @@ class Test0TreecheckFixtBalderglobScenarioConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.ERROR
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_construction.py
@@ -175,7 +175,7 @@ class Test0TreecheckFixtBalderglobScenarioConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
@@ -345,7 +345,7 @@ class Test0TreecheckFixtBalderglobScenarioTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.ERROR
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
@@ -337,7 +337,7 @@ class Test0TreecheckFixtBalderglobScenarioTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
@@ -361,7 +361,7 @@ class Test0TreecheckFixtBalderglobScenarioTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_scenario_teardown.py
@@ -353,7 +353,7 @@ class Test0TreecheckFixtBalderglobScenarioTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.ERROR
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
@@ -47,7 +47,7 @@ class Test0TreecheckFixtBalderglobSessionConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.NOT_RUN"
         assert session.executor_tree.teardown_result.result == ResultState.NOT_RUN, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.NOT_RUN, \
                 "the setup executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
@@ -71,7 +71,7 @@ class Test0TreecheckFixtBalderglobSessionConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
@@ -63,7 +63,7 @@ class Test0TreecheckFixtBalderglobSessionConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_construction.py
@@ -55,7 +55,7 @@ class Test0TreecheckFixtBalderglobSessionConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
             assert cur_setup_executor.teardown_result.result == ResultState.NOT_RUN
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                     "the scenario executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
@@ -337,7 +337,7 @@ class Test0TreecheckFixtBalderglobSessionTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.ERROR, \
             "global executor tree teardown part does not set ResultState.ERROR"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
@@ -353,7 +353,7 @@ class Test0TreecheckFixtBalderglobSessionTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
@@ -361,7 +361,7 @@ class Test0TreecheckFixtBalderglobSessionTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_session_teardown.py
@@ -345,7 +345,7 @@ class Test0TreecheckFixtBalderglobSessionTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
@@ -141,7 +141,7 @@ class Test0TreecheckFixtBalderglobSetupConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
@@ -133,7 +133,7 @@ class Test0TreecheckFixtBalderglobSetupConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
@@ -125,7 +125,7 @@ class Test0TreecheckFixtBalderglobSetupConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
             assert cur_setup_executor.teardown_result.result == ResultState.NOT_RUN
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                     "the scenario executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_construction.py
@@ -117,7 +117,7 @@ class Test0TreecheckFixtBalderglobSetupConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
@@ -353,7 +353,7 @@ class Test0TreecheckFixtBalderglobSetupTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
@@ -337,7 +337,7 @@ class Test0TreecheckFixtBalderglobSetupTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
@@ -345,7 +345,7 @@ class Test0TreecheckFixtBalderglobSetupTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.ERROR
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_setup_teardown.py
@@ -361,7 +361,7 @@ class Test0TreecheckFixtBalderglobSetupTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
@@ -281,7 +281,7 @@ class Test0TreecheckFixtBalderglobTestcaseConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.ERROR
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.ERROR, \
                             "the testcase executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
@@ -257,7 +257,7 @@ class Test0TreecheckFixtBalderglobTestcaseConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
@@ -265,7 +265,7 @@ class Test0TreecheckFixtBalderglobTestcaseConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.ERROR
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_construction.py
@@ -273,7 +273,7 @@ class Test0TreecheckFixtBalderglobTestcaseConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.ERROR
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.ERROR, \
                         "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
@@ -337,7 +337,7 @@ class Test0TreecheckFixtBalderglobTestcaseTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
@@ -345,7 +345,7 @@ class Test0TreecheckFixtBalderglobTestcaseTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.ERROR
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
@@ -361,7 +361,7 @@ class Test0TreecheckFixtBalderglobTestcaseTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.ERROR
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.ERROR, \
                             "the testcase executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_testcase_teardown.py
@@ -353,7 +353,7 @@ class Test0TreecheckFixtBalderglobTestcaseTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.ERROR
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.ERROR, \
                         "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
@@ -205,7 +205,7 @@ class Test0TreecheckFixtBalderglobVariationConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.ERROR
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
@@ -213,7 +213,7 @@ class Test0TreecheckFixtBalderglobVariationConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.ERROR
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.ERROR, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
@@ -221,7 +221,7 @@ class Test0TreecheckFixtBalderglobVariationConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_construction.py
@@ -197,7 +197,7 @@ class Test0TreecheckFixtBalderglobVariationConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
@@ -361,7 +361,7 @@ class Test0TreecheckFixtBalderglobVariationTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.ERROR
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
@@ -353,7 +353,7 @@ class Test0TreecheckFixtBalderglobVariationTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.ERROR
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.ERROR, \
                         "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
@@ -345,7 +345,7 @@ class Test0TreecheckFixtBalderglobVariationTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.ERROR
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_balderglob_variation_teardown.py
@@ -337,7 +337,7 @@ class Test0TreecheckFixtBalderglobVariationTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.ERROR, \
                 "the setup executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
@@ -297,7 +297,7 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                         assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -321,7 +321,7 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
@@ -262,7 +262,7 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
@@ -279,7 +279,7 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 if cur_scenario_executor.base_scenario_class.__class__.__name__ == "ScenarioA":
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_construction.py
@@ -289,7 +289,7 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
                     # success here because other items were already run in this section
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                             "the variation executor does not have result NOT_RUN"
 
@@ -313,7 +313,7 @@ class Test0TreecheckFixtScenarioaScenarioConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
@@ -349,7 +349,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -381,7 +381,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
@@ -340,7 +340,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
@@ -357,7 +357,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.ERROR
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result NOT_RUN"
 
@@ -389,7 +389,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_scenario_teardown.py
@@ -365,7 +365,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 
@@ -397,7 +397,7 @@ class Test0TreecheckFixtScenarioaScenarioTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
@@ -140,7 +140,7 @@ class Test0TreecheckFixtScenarioaSessionConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
             assert cur_setup_executor.teardown_result.result == ResultState.NOT_RUN
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                     "the scenario executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
@@ -132,7 +132,7 @@ class Test0TreecheckFixtScenarioaSessionConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.NOT_RUN"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.NOT_RUN, \
                 "the setup executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
@@ -156,7 +156,7 @@ class Test0TreecheckFixtScenarioaSessionConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_construction.py
@@ -148,7 +148,7 @@ class Test0TreecheckFixtScenarioaSessionConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
@@ -341,7 +341,7 @@ class Test0TreecheckFixtScenarioaSessionTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.ERROR, \
             "global executor tree teardown part does not set ResultState.ERROR"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
@@ -365,7 +365,7 @@ class Test0TreecheckFixtScenarioaSessionTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
@@ -349,7 +349,7 @@ class Test0TreecheckFixtScenarioaSessionTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_session_teardown.py
@@ -357,7 +357,7 @@ class Test0TreecheckFixtScenarioaSessionTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
@@ -261,7 +261,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                             "the variation executor does not have result NOT_RUN"
 
@@ -293,7 +293,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
@@ -244,7 +244,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
@@ -269,7 +269,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                         assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -301,7 +301,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_construction.py
@@ -253,7 +253,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                         "the scenario executor does not have result NOT_RUN"
 
@@ -285,7 +285,7 @@ class Test0TreecheckFixtScenarioaSetupConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
@@ -375,7 +375,7 @@ class Test0TreecheckFixtScenarioaSetupTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
@@ -367,7 +367,7 @@ class Test0TreecheckFixtScenarioaSetupTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
@@ -341,7 +341,7 @@ class Test0TreecheckFixtScenarioaSetupTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_setup_teardown.py
@@ -359,7 +359,7 @@ class Test0TreecheckFixtScenarioaSetupTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
@@ -347,7 +347,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -378,7 +378,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
@@ -355,7 +355,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.ERROR
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.ERROR, \
                                 "the testcase executor does not have result ERROR"
 
@@ -386,7 +386,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
@@ -339,7 +339,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -370,7 +370,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_construction.py
@@ -330,7 +330,7 @@ class Test0TreecheckFixtScenarioaTestcaseConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
@@ -366,7 +366,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.ERROR
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.ERROR, \
                                 "the testcase executor does not have result ERROR"
 
@@ -397,7 +397,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
@@ -358,7 +358,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -389,7 +389,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
@@ -350,7 +350,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -381,7 +381,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_testcase_teardown.py
@@ -341,7 +341,7 @@ class Test0TreecheckFixtScenarioaTestcaseTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
@@ -309,7 +309,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -340,7 +340,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
@@ -301,7 +301,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -332,7 +332,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
@@ -293,7 +293,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -324,7 +324,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_construction.py
@@ -284,7 +284,7 @@ class Test0TreecheckFixtScenarioaVariationConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
@@ -341,7 +341,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
@@ -366,7 +366,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.ERROR
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -397,7 +397,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
@@ -350,7 +350,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -381,7 +381,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_scenarioa_variation_teardown.py
@@ -358,7 +358,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -389,7 +389,7 @@ class Test0TreecheckFixtScenarioaVariationTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
@@ -274,7 +274,7 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 if cur_scenario_executor.base_scenario_class.__class__.__name__ == "ScenarioA":
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
@@ -284,7 +284,7 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
                     # success here because other items were already run in this section
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                             "the variation executor does not have result NOT_RUN"
 
@@ -308,7 +308,7 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
@@ -257,7 +257,7 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_construction.py
@@ -292,7 +292,7 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                         assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -316,7 +316,7 @@ class Test0TreecheckFixtSetupaScenarioConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
@@ -341,7 +341,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
@@ -358,7 +358,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.ERROR
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result NOT_RUN"
 
@@ -390,7 +390,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
@@ -366,7 +366,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 
@@ -398,7 +398,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_scenario_teardown.py
@@ -350,7 +350,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -382,7 +382,7 @@ class Test0TreecheckFixtSetupaScenarioTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
@@ -105,7 +105,7 @@ class Test0TreecheckFixtSetupaSessionConstruction(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
@@ -97,7 +97,7 @@ class Test0TreecheckFixtSetupaSessionConstruction(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
@@ -81,7 +81,7 @@ class Test0TreecheckFixtSetupaSessionConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.NOT_RUN"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.NOT_RUN, \
                 "the setup executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_construction.py
@@ -89,7 +89,7 @@ class Test0TreecheckFixtSetupaSessionConstruction(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
             assert cur_setup_executor.teardown_result.result == ResultState.NOT_RUN
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                     "the scenario executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
@@ -357,7 +357,7 @@ class Test0TreecheckFixtSetupaSessionTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
@@ -341,7 +341,7 @@ class Test0TreecheckFixtSetupaSessionTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.ERROR, \
             "global executor tree teardown part does not set ResultState.ERROR"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
@@ -365,7 +365,7 @@ class Test0TreecheckFixtSetupaSessionTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_session_teardown.py
@@ -349,7 +349,7 @@ class Test0TreecheckFixtSetupaSessionTeardown(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
@@ -253,7 +253,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                             "the variation executor does not have result NOT_RUN"
 
@@ -285,7 +285,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
@@ -261,7 +261,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                         assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -293,7 +293,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
@@ -236,7 +236,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_construction.py
@@ -245,7 +245,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                         "the scenario executor does not have result NOT_RUN"
 
@@ -277,7 +277,7 @@ class Test0TreecheckFixtSetupaSetupConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
@@ -342,7 +342,7 @@ class Test0TreecheckFixtSetupaSetupTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
@@ -376,7 +376,7 @@ class Test0TreecheckFixtSetupaSetupTeardown(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
@@ -368,7 +368,7 @@ class Test0TreecheckFixtSetupaSetupTeardown(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_setup_teardown.py
@@ -360,7 +360,7 @@ class Test0TreecheckFixtSetupaSetupTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
@@ -314,7 +314,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
@@ -339,7 +339,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.ERROR
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.ERROR, \
                                 "the testcase executor does not have result ERROR"
 
@@ -370,7 +370,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
@@ -331,7 +331,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -362,7 +362,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_construction.py
@@ -323,7 +323,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -354,7 +354,7 @@ class Test0TreecheckFixtSetupaTestcaseConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
@@ -370,7 +370,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.ERROR
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.ERROR, \
                                 "the testcase executor does not have result ERROR"
 
@@ -401,7 +401,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
@@ -345,7 +345,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
@@ -362,7 +362,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -393,7 +393,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_testcase_teardown.py
@@ -354,7 +354,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -385,7 +385,7 @@ class Test0TreecheckFixtSetupaTestcaseTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
@@ -276,7 +276,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.NOT_RUN"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
@@ -293,7 +293,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -324,7 +324,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
@@ -301,7 +301,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -332,7 +332,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result NOT_RUN"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_construction.py
@@ -285,7 +285,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -316,7 +316,7 @@ class Test0TreecheckFixtSetupaVariationConstruction(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result ERROR"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
@@ -359,7 +359,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.ERROR
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.ERROR, \
                             "the variation executor does not have result ERROR"
 
@@ -390,7 +390,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
@@ -367,7 +367,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.ERROR
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result NOT_RUN"
 
@@ -398,7 +398,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
@@ -342,7 +342,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.ERROR, \
                     "the setup executor does not have result ERROR"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_fixt_setupa_variation_teardown.py
@@ -351,7 +351,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.ERROR
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.ERROR, \
                         "the scenario executor does not have result ERROR"
 
@@ -382,7 +382,7 @@ class Test0TreecheckFixtSetupaVariationTeardown(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
@@ -341,7 +341,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.ERROR"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             if cur_setup_executor.base_setup_class.__class__.__name__ == "SetupA":
                 assert cur_setup_executor.executor_result == ResultState.FAILURE, \
                     "the setup executor does not have result FAILURE"

--- a/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
@@ -358,7 +358,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.FAILURE
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.FAILURE, \
                             "the variation executor does not have result FAILURE"
 
@@ -397,7 +397,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
                     assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                     assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_variation_executor in cur_scenario_executor.variation_executors:
+                    for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                         assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                             "the variation executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
@@ -366,7 +366,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.FAILURE
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             if cur_testcase_executor.base_testcase_callable.__name__ == "test_a_1":
                                 assert cur_testcase_executor.executor_result == ResultState.FAILURE, \
                                     "the testcase executor does not have result FAILURE"
@@ -405,7 +405,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
                         assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                         assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                        for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                        for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                             assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                                 "the testcase executor does not have result SUCCESS"
 

--- a/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
+++ b/tests/executor/test_0_treecheck/test_0_treecheck_test_scenarioa_testa1.py
@@ -350,7 +350,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.FAILURE
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.FAILURE, \
                         "the scenario executor does not have result FAILURE"
 
@@ -389,7 +389,7 @@ class Test0TreecheckTestScenarioaTesta1(Base0EnvtesterClass):
                 assert cur_setup_executor.body_result.result == ResultState.SUCCESS
                 assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_scenario_executor in cur_setup_executor.scenario_executors:
+                for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                     assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                         "the scenario executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
+++ b/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
@@ -185,7 +185,7 @@ class Test0ClassmethodFixture(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
+++ b/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
@@ -193,7 +193,7 @@ class Test0ClassmethodFixture(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
+++ b/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
@@ -177,7 +177,7 @@ class Test0ClassmethodFixture(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
+++ b/tests/fixtures/test_0_classmethod_fixture/test_0_classmethod_fixture.py
@@ -169,7 +169,7 @@ class Test0ClassmethodFixture(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
+++ b/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
@@ -171,7 +171,7 @@ class Test0InstancemethodFixture(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
+++ b/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
@@ -179,7 +179,7 @@ class Test0InstancemethodFixture(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
+++ b/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
@@ -163,7 +163,7 @@ class Test0InstancemethodFixture(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
+++ b/tests/fixtures/test_0_instancemethod_fixture/test_0_instancemethod_fixture.py
@@ -187,7 +187,7 @@ class Test0InstancemethodFixture(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
+++ b/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
@@ -339,7 +339,7 @@ class Test0SameNameFixture(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
+++ b/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
@@ -331,7 +331,7 @@ class Test0SameNameFixture(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
+++ b/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
@@ -347,7 +347,7 @@ class Test0SameNameFixture(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
+++ b/tests/fixtures/test_0_same_name_fixture/test_0_same_name_fixture.py
@@ -323,7 +323,7 @@ class Test0SameNameFixture(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
+++ b/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
@@ -167,7 +167,7 @@ class Test0StaticmethodFixture(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
+++ b/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
@@ -191,7 +191,7 @@ class Test0StaticmethodFixture(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
+++ b/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
@@ -183,7 +183,7 @@ class Test0StaticmethodFixture(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
+++ b/tests/fixtures/test_0_staticmethod_fixture/test_0_staticmethod_fixture.py
@@ -175,7 +175,7 @@ class Test0StaticmethodFixture(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
+++ b/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
@@ -53,7 +53,7 @@ class Test0UnclearSetupScopedFixtureReference(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.NOT_RUN"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.NOT_RUN, \
                 "the setup executor does not have result NOT_RUN"
 

--- a/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
+++ b/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
@@ -61,7 +61,7 @@ class Test0UnclearSetupScopedFixtureReference(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.NOT_RUN
             assert cur_setup_executor.teardown_result.result == ResultState.NOT_RUN
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.NOT_RUN, \
                     "the scenario executor does not have result NOT_RUN"
 

--- a/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
+++ b/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
@@ -77,7 +77,7 @@ class Test0UnclearSetupScopedFixtureReference(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.NOT_RUN
                     assert cur_variation_executor.teardown_result.result == ResultState.NOT_RUN
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.NOT_RUN, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
+++ b/tests/fixtures/test_0_unclear_setup_scoped_fixture_reference/test_0_unclear_setup_scoped_fixture_reference.py
@@ -69,7 +69,7 @@ class Test0UnclearSetupScopedFixtureReference(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.NOT_RUN
                 assert cur_scenario_executor.teardown_result.result == ResultState.NOT_RUN
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.NOT_RUN, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
+++ b/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
@@ -251,7 +251,7 @@ class Test0ExactlyOneMoreFeatureInSetup(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
+++ b/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
@@ -235,7 +235,7 @@ class Test0ExactlyOneMoreFeatureInSetup(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
+++ b/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
@@ -243,7 +243,7 @@ class Test0ExactlyOneMoreFeatureInSetup(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
+++ b/tests/matching/test_0_exactly_one_more_feature_in_setup/test_0_exactly_one_more_feature_in_setup.py
@@ -227,7 +227,7 @@ class Test0ExactlyOneMoreFeatureInSetup(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
+++ b/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
@@ -438,7 +438,7 @@ class Test0MultipleVariations(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
+++ b/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
@@ -446,7 +446,7 @@ class Test0MultipleVariations(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
+++ b/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
@@ -454,7 +454,7 @@ class Test0MultipleVariations(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
+++ b/tests/matching/test_0_multiple_variations/test_0_multiple_variations.py
@@ -430,7 +430,7 @@ class Test0MultipleVariations(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
@@ -339,7 +339,7 @@ class Test0NoMultipleVariationsForNonConnection(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
@@ -355,7 +355,7 @@ class Test0NoMultipleVariationsForNonConnection(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
@@ -347,7 +347,7 @@ class Test0NoMultipleVariationsForNonConnection(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_non_connection/test_0_no_multiple_variations_for_non_connection.py
@@ -363,7 +363,7 @@ class Test0NoMultipleVariationsForNonConnection(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
@@ -363,7 +363,7 @@ class Test0NoMultipleVariationsForWrongConnection(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
@@ -339,7 +339,7 @@ class Test0NoMultipleVariationsForWrongConnection(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
@@ -355,7 +355,7 @@ class Test0NoMultipleVariationsForWrongConnection(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
+++ b/tests/matching/test_0_no_multiple_variations_for_wrong_connection/test_0_no_multiple_variations_for_wrong_connection.py
@@ -347,7 +347,7 @@ class Test0NoMultipleVariationsForWrongConnection(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/matching/test_1_no_scenario_devices/test_1_no_scenario_devices.py
+++ b/tests/matching/test_1_no_scenario_devices/test_1_no_scenario_devices.py
@@ -28,7 +28,7 @@ def processed(env_dir):
     assert len(session.executor_tree.all_child_executors) == 1, "found not exactly one matching setup"
     setup_executor = session.executor_tree.get_setup_executors()[0]
     assert setup_executor.base_setup_class.__class__.__name__ == "SetupPythonAdd", "unexpected matching setup"
-    assert len(setup_executor.scenario_executors) == 1, "found not exactly one matching scenario"
-    scenario_executor = setup_executor.scenario_executors[0]
+    assert len(setup_executor.get_scenario_executors()) == 1, "found not exactly one matching scenario"
+    scenario_executor = setup_executor.get_scenario_executors()[0]
     assert scenario_executor.base_scenario_class.__class__.__name__ == "ScenarioAdding", "unexpected matching scenario"
     assert len(scenario_executor.variation_executors) == 1, "found not exactly one matching scenario"

--- a/tests/matching/test_1_no_scenario_devices/test_1_no_scenario_devices.py
+++ b/tests/matching/test_1_no_scenario_devices/test_1_no_scenario_devices.py
@@ -26,7 +26,7 @@ def processed(env_dir):
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
     assert len(session.executor_tree.all_child_executors) == 1, "found not exactly one matching setup"
-    setup_executor = session.executor_tree.setup_executors[0]
+    setup_executor = session.executor_tree.get_setup_executors()[0]
     assert setup_executor.base_setup_class.__class__.__name__ == "SetupPythonAdd", "unexpected matching setup"
     assert len(setup_executor.scenario_executors) == 1, "found not exactly one matching scenario"
     scenario_executor = setup_executor.scenario_executors[0]

--- a/tests/matching/test_1_no_scenario_devices/test_1_no_scenario_devices.py
+++ b/tests/matching/test_1_no_scenario_devices/test_1_no_scenario_devices.py
@@ -31,4 +31,4 @@ def processed(env_dir):
     assert len(setup_executor.get_scenario_executors()) == 1, "found not exactly one matching scenario"
     scenario_executor = setup_executor.get_scenario_executors()[0]
     assert scenario_executor.base_scenario_class.__class__.__name__ == "ScenarioAdding", "unexpected matching scenario"
-    assert len(scenario_executor.variation_executors) == 1, "found not exactly one matching scenario"
+    assert len(scenario_executor.get_variation_executors()) == 1, "found not exactly one matching scenario"

--- a/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
+++ b/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
@@ -192,7 +192,7 @@ class Test0ScenarioDeviceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
+++ b/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
@@ -208,7 +208,7 @@ class Test0ScenarioDeviceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
+++ b/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
@@ -200,7 +200,7 @@ class Test0ScenarioDeviceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
+++ b/tests/scenario_inheritance/test_0_scenario_correctly_overwrite_and_add_feature/test_0_scenario_device_correctly_overwrite_and_add_feature.py
@@ -216,7 +216,7 @@ class Test0ScenarioDeviceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
+++ b/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
@@ -165,7 +165,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
+++ b/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
@@ -189,7 +189,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
+++ b/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
@@ -181,7 +181,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
+++ b/tests/scenario_inheritance/test_0_scenario_define_new_device/test_0_scenario_inheritance_define_new_device.py
@@ -173,7 +173,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
+++ b/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
@@ -263,7 +263,7 @@ class Test0ScenarioInheritanceFixtureInheritance(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
+++ b/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
@@ -271,7 +271,7 @@ class Test0ScenarioInheritanceFixtureInheritance(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
+++ b/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
@@ -279,7 +279,7 @@ class Test0ScenarioInheritanceFixtureInheritance(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
+++ b/tests/scenario_inheritance/test_0_scenario_fixture_inheritance/test_0_scenario_inheritance_fixture_inheritance.py
@@ -287,7 +287,7 @@ class Test0ScenarioInheritanceFixtureInheritance(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
+++ b/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
@@ -167,7 +167,7 @@ class Test0ScenarioInheritanceNotOverwriteDevices(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
+++ b/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
@@ -183,7 +183,7 @@ class Test0ScenarioInheritanceNotOverwriteDevices(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
+++ b/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
@@ -191,7 +191,7 @@ class Test0ScenarioInheritanceNotOverwriteDevices(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
+++ b/tests/scenario_inheritance/test_0_scenario_not_overwrite_devices/test_0_scenario_inheritance_not_overwrite_devices.py
@@ -175,7 +175,7 @@ class Test0ScenarioInheritanceNotOverwriteDevices(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/scenario_inheritance/test_1_scenario_overwrite_parent_connections/test_1_scenario_inheritance_overwrite_parent_connections.py
+++ b/tests/scenario_inheritance/test_1_scenario_overwrite_parent_connections/test_1_scenario_inheritance_overwrite_parent_connections.py
@@ -33,7 +33,7 @@ def processed(env_dir):
     assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong setup class was executed"
 
-    scenario_executors = session.executor_tree.get_setup_executors()[0].scenario_executors
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
 
     assert len(scenario_executors) == 1, \
         "not exactly one scenario executor found"

--- a/tests/scenario_inheritance/test_1_scenario_overwrite_parent_connections/test_1_scenario_inheritance_overwrite_parent_connections.py
+++ b/tests/scenario_inheritance/test_1_scenario_overwrite_parent_connections/test_1_scenario_inheritance_overwrite_parent_connections.py
@@ -28,12 +28,12 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "not exactly one setup executor found"
-    assert session.executor_tree.setup_executors[0].base_setup_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong setup class was executed"
 
-    scenario_executors = session.executor_tree.setup_executors[0].scenario_executors
+    scenario_executors = session.executor_tree.get_setup_executors()[0].scenario_executors
 
     assert len(scenario_executors) == 1, \
         "not exactly one scenario executor found"

--- a/tests/scenario_inheritance/test_1_scenario_overwrite_parent_connections/test_1_scenario_inheritance_overwrite_parent_connections.py
+++ b/tests/scenario_inheritance/test_1_scenario_overwrite_parent_connections/test_1_scenario_inheritance_overwrite_parent_connections.py
@@ -39,4 +39,4 @@ def processed(env_dir):
         "not exactly one scenario executor found"
     assert scenario_executors[0].base_scenario_class.__class__.__name__ == "ScenarioAddingChild", \
         "wrong scenario class was executed"
-    assert len(scenario_executors[0].variation_executors) == 1, "not exactly one variation executor found"
+    assert len(scenario_executors[0].get_variation_executors()) == 1, "not exactly one variation executor found"

--- a/tests/scenario_inheritance/test_1_scenario_use_parent_connections/test_1_scenario_inheritance_use_parent_connections.py
+++ b/tests/scenario_inheritance/test_1_scenario_use_parent_connections/test_1_scenario_inheritance_use_parent_connections.py
@@ -29,13 +29,13 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "not exactly one setup executor found"
-    assert session.executor_tree.setup_executors[0].base_setup_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
         "not exactly one scenario executor found"
-    assert session.executor_tree.setup_executors[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
            "ScenarioAddingChild", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors) == 2, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 2, \
         "not exactly two variation executor found"

--- a/tests/scenario_inheritance/test_1_scenario_use_parent_connections/test_1_scenario_inheritance_use_parent_connections.py
+++ b/tests/scenario_inheritance/test_1_scenario_use_parent_connections/test_1_scenario_inheritance_use_parent_connections.py
@@ -39,5 +39,4 @@ def processed(env_dir):
     assert len(scenario_executors) == 1, "not exactly one scenario executor found"
     assert scenario_executors[0].base_scenario_class.__class__.__name__ == "ScenarioAddingChild", \
         "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()[0].variation_executors) == 2, \
-        "not exactly two variation executor found"
+    assert len(scenario_executors[0].get_variation_executors()) == 2, "not exactly two variation executor found"

--- a/tests/scenario_inheritance/test_1_scenario_use_parent_connections/test_1_scenario_inheritance_use_parent_connections.py
+++ b/tests/scenario_inheritance/test_1_scenario_use_parent_connections/test_1_scenario_inheritance_use_parent_connections.py
@@ -33,9 +33,11 @@ def processed(env_dir):
         "not exactly one setup executor found"
     assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
-        "not exactly one scenario executor found"
-    assert session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-           "ScenarioAddingChild", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 2, \
+
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
+
+    assert len(scenario_executors) == 1, "not exactly one scenario executor found"
+    assert scenario_executors[0].base_scenario_class.__class__.__name__ == "ScenarioAddingChild", \
+        "wrong scenario class was executed"
+    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()[0].variation_executors) == 2, \
         "not exactly two variation executor found"

--- a/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
+++ b/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
@@ -186,7 +186,7 @@ class Test0SetupInheritanceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
+++ b/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
@@ -178,7 +178,7 @@ class Test0SetupInheritanceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
+++ b/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
@@ -202,7 +202,7 @@ class Test0SetupInheritanceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
+++ b/tests/setup_inheritance/test_0_setup_correctly_overwrite_and_add_feature/test_0_setup_inheritance_correctly_overwrite_and_add_feature.py
@@ -194,7 +194,7 @@ class Test0SetupInheritanceCorrectlyOverwriteAndAddFeature(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
+++ b/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
@@ -165,7 +165,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
+++ b/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
@@ -189,7 +189,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
+++ b/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
@@ -181,7 +181,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
+++ b/tests/setup_inheritance/test_0_setup_define_new_device/test_0_setup_inheritance_define_new_device.py
@@ -173,7 +173,7 @@ class Test0ScenarioInheritanceDefineNewDevice(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
+++ b/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
@@ -287,7 +287,7 @@ class Test0SetupInheritanceFixtureInheritance(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
+++ b/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
@@ -263,7 +263,7 @@ class Test0SetupInheritanceFixtureInheritance(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
+++ b/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
@@ -271,7 +271,7 @@ class Test0SetupInheritanceFixtureInheritance(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
+++ b/tests/setup_inheritance/test_0_setup_fixture_inheritance/test_0_setup_inheritance_fixture_inheritance.py
@@ -279,7 +279,7 @@ class Test0SetupInheritanceFixtureInheritance(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
+++ b/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
@@ -175,7 +175,7 @@ class Test0SetupInheritanceNotOverwriteDevices(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
+++ b/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
@@ -191,7 +191,7 @@ class Test0SetupInheritanceNotOverwriteDevices(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
+++ b/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
@@ -183,7 +183,7 @@ class Test0SetupInheritanceNotOverwriteDevices(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
+++ b/tests/setup_inheritance/test_0_setup_not_overwrite_devices/test_0_setup_inheritance_not_overwrite_devices.py
@@ -167,7 +167,7 @@ class Test0SetupInheritanceNotOverwriteDevices(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/setup_inheritance/test_1_setup_overwrite_parent_connections/test_1_setup_inheritance_overwrite_parent_connections.py
+++ b/tests/setup_inheritance/test_1_setup_overwrite_parent_connections/test_1_setup_inheritance_overwrite_parent_connections.py
@@ -34,7 +34,7 @@ def processed(env_dir):
     assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAddChild", "wrong scenario class was executed"
 
-    scenario_executors = session.executor_tree.get_setup_executors()[0].scenario_executors
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
 
     assert len(scenario_executors) == 1, \
         "not exactly one scenario executor found"

--- a/tests/setup_inheritance/test_1_setup_overwrite_parent_connections/test_1_setup_inheritance_overwrite_parent_connections.py
+++ b/tests/setup_inheritance/test_1_setup_overwrite_parent_connections/test_1_setup_inheritance_overwrite_parent_connections.py
@@ -29,12 +29,12 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "not exactly one setup executor found"
-    assert session.executor_tree.setup_executors[0].base_setup_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAddChild", "wrong scenario class was executed"
 
-    scenario_executors = session.executor_tree.setup_executors[0].scenario_executors
+    scenario_executors = session.executor_tree.get_setup_executors()[0].scenario_executors
 
     assert len(scenario_executors) == 1, \
         "not exactly one scenario executor found"

--- a/tests/setup_inheritance/test_1_setup_overwrite_parent_connections/test_1_setup_inheritance_overwrite_parent_connections.py
+++ b/tests/setup_inheritance/test_1_setup_overwrite_parent_connections/test_1_setup_inheritance_overwrite_parent_connections.py
@@ -40,4 +40,4 @@ def processed(env_dir):
         "not exactly one scenario executor found"
     assert scenario_executors[0].base_scenario_class.__class__.__name__ == "ScenarioAdding", \
         "wrong scenario class was executed"
-    assert len(scenario_executors[0].variation_executors) == 1, "not exactly one variation executor found"
+    assert len(scenario_executors[0].get_variation_executors()) == 1, "not exactly one variation executor found"

--- a/tests/setup_inheritance/test_1_setup_use_parent_connections/test_1_setup_inheritance_use_parent_connections.py
+++ b/tests/setup_inheritance/test_1_setup_use_parent_connections/test_1_setup_inheritance_use_parent_connections.py
@@ -31,10 +31,11 @@ def processed(env_dir):
         "not exactly one setup executor found"
     assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAddChild", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
-        "not exactly one scenario executor found"
-    assert \
-        session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-        "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 2, \
+
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
+
+    assert len(scenario_executors) == 1, "not exactly one scenario executor found"
+    assert scenario_executors[0].base_scenario_class.__class__.__name__ == \
+           "ScenarioAdding", "wrong scenario class was executed"
+    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()[0].variation_executors) == 2, \
         "not exactly two variation executor found"

--- a/tests/setup_inheritance/test_1_setup_use_parent_connections/test_1_setup_inheritance_use_parent_connections.py
+++ b/tests/setup_inheritance/test_1_setup_use_parent_connections/test_1_setup_inheritance_use_parent_connections.py
@@ -37,5 +37,4 @@ def processed(env_dir):
     assert len(scenario_executors) == 1, "not exactly one scenario executor found"
     assert scenario_executors[0].base_scenario_class.__class__.__name__ == \
            "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()[0].variation_executors) == 2, \
-        "not exactly two variation executor found"
+    assert len(scenario_executors[0].get_variation_executors()) == 2, "not exactly two variation executor found"

--- a/tests/setup_inheritance/test_1_setup_use_parent_connections/test_1_setup_inheritance_use_parent_connections.py
+++ b/tests/setup_inheritance/test_1_setup_use_parent_connections/test_1_setup_inheritance_use_parent_connections.py
@@ -27,13 +27,14 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "not exactly one setup executor found"
-    assert session.executor_tree.setup_executors[0].base_setup_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAddChild", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
         "not exactly one scenario executor found"
-    assert session.executor_tree.setup_executors[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-           "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors) == 2, \
+    assert \
+        session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
+        "ScenarioAdding", "wrong scenario class was executed"
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 2, \
         "not exactly two variation executor found"

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
@@ -168,7 +168,7 @@ class Test0ClassbasedVdeviceScenariomapScenariodefScenariofeat(Base0EnvtesterCla
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
@@ -184,7 +184,7 @@ class Test0ClassbasedVdeviceScenariomapScenariodefScenariofeat(Base0EnvtesterCla
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
@@ -192,7 +192,7 @@ class Test0ClassbasedVdeviceScenariomapScenariodefScenariofeat(Base0EnvtesterCla
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariodef_scenariofeat/test_0_scenariomap_scenariodef_scenariofeat.py
@@ -176,7 +176,7 @@ class Test0ClassbasedVdeviceScenariomapScenariodefScenariofeat(Base0EnvtesterCla
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
@@ -177,7 +177,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefScenariofeat(Base0Envtest
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
@@ -169,7 +169,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefScenariofeat(Base0Envtest
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
@@ -193,7 +193,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefScenariofeat(Base0Envtest
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_scenariofeat/test_0_scenariomap_scenariosetupdef_scenariofeat.py
@@ -185,7 +185,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefScenariofeat(Base0Envtest
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
@@ -168,7 +168,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefSetupfeat(Base0EnvtesterC
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
@@ -176,7 +176,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefSetupfeat(Base0EnvtesterC
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
@@ -184,7 +184,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefSetupfeat(Base0EnvtesterC
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariomap_scenariosetupdef_setupfeat/test_0_scenariomap_scenariosetupdef_setupfeat.py
@@ -192,7 +192,7 @@ class Test0ClassbasedVdeviceScenariomapScenariosetupdefSetupfeat(Base0EnvtesterC
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
@@ -173,7 +173,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefScenariofeat(Base0Envtest
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
@@ -181,7 +181,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefScenariofeat(Base0Envtest
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
@@ -197,7 +197,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefScenariofeat(Base0Envtest
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_scenariofeat/test_0_scenariosetupmap_scenariodef_scenariofeat.py
@@ -189,7 +189,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefScenariofeat(Base0Envtest
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
@@ -173,7 +173,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefSetupfeat(Base0EnvtesterC
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
@@ -197,7 +197,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefSetupfeat(Base0EnvtesterC
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
@@ -181,7 +181,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefSetupfeat(Base0EnvtesterC
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariodef_setupfeat/test_0_scenariosetupmap_scenariodef_setupfeat.py
@@ -189,7 +189,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariodefSetupfeat(Base0EnvtesterC
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
@@ -181,7 +181,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefScenariofeat(Base0En
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
@@ -197,7 +197,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefScenariofeat(Base0En
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
@@ -173,7 +173,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefScenariofeat(Base0En
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_scenariofeat/test_0_scenariosetupmap_scenariosetupdef_scenariofeat.py
@@ -189,7 +189,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefScenariofeat(Base0En
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
@@ -189,7 +189,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefSetupfeat(Base0Envte
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
@@ -173,7 +173,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefSetupfeat(Base0Envte
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
@@ -197,7 +197,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefSetupfeat(Base0Envte
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_scenariosetupmap_scenariosetupdef_setupfeat/test_0_scenariosetupmap_scenariosetupdef_setupfeat.py
@@ -181,7 +181,7 @@ class Test0ClassbasedVdeviceScenariosetupmapScenariosetupdefSetupfeat(Base0Envte
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
@@ -169,7 +169,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefScenariofeat(Base0EnvtesterClass)
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
@@ -177,7 +177,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefScenariofeat(Base0EnvtesterClass)
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
@@ -185,7 +185,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefScenariofeat(Base0EnvtesterClass)
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_scenariofeat/test_0_setupmap_scenariodef_scenariofeat.py
@@ -193,7 +193,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefScenariofeat(Base0EnvtesterClass)
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
@@ -177,7 +177,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefSetupfeat(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
@@ -193,7 +193,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefSetupfeat(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
@@ -185,7 +185,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefSetupfeat(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariodef_setupfeat/test_0_setupmap_scenariodef_setupfeat.py
@@ -169,7 +169,7 @@ class Test0ClassbasedVdeviceSetupmapScenariodefSetupfeat(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
@@ -193,7 +193,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefScenariofeat(Base0EnvtesterC
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
@@ -169,7 +169,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefScenariofeat(Base0EnvtesterC
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
@@ -185,7 +185,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefScenariofeat(Base0EnvtesterC
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_scenariofeat/test_0_setupmap_scenariosetupdef_scenariofeat.py
@@ -177,7 +177,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefScenariofeat(Base0EnvtesterC
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
@@ -185,7 +185,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefSetupfeat(Base0EnvtesterClas
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
@@ -193,7 +193,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefSetupfeat(Base0EnvtesterClas
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
@@ -177,7 +177,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefSetupfeat(Base0EnvtesterClas
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_scenariosetupdef_setupfeat/test_0_setupmap_scenariosetupdef_setupfeat.py
@@ -169,7 +169,7 @@ class Test0ClassbasedVdeviceSetupmapScenariosetupdefSetupfeat(Base0EnvtesterClas
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
@@ -170,7 +170,7 @@ class Test0ClassbasedVdeviceSetupmapSetupdefSetupfeat(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
@@ -186,7 +186,7 @@ class Test0ClassbasedVdeviceSetupmapSetupdefSetupfeat(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
@@ -178,7 +178,7 @@ class Test0ClassbasedVdeviceSetupmapSetupdefSetupfeat(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
+++ b/tests/vdevice/classbased/test_0_setupmap_setupdef_setupfeat/test_0_setupmap_setupdef_setupfeat.py
@@ -194,7 +194,7 @@ class Test0ClassbasedVdeviceSetupmapSetupdefSetupfeat(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
@@ -192,7 +192,7 @@ class Test0FeatOverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
@@ -200,7 +200,7 @@ class Test0FeatOverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
@@ -184,7 +184,7 @@ class Test0FeatOverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_befsce/test_0_feat_overwrite_correctly_and_add_befsce.py
@@ -176,7 +176,7 @@ class Test0FeatOverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
@@ -179,7 +179,7 @@ class Test0FeatOverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
@@ -195,7 +195,7 @@ class Test0FeatOverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
@@ -187,7 +187,7 @@ class Test0FeatOverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_feat_overwrite_correctly_and_add_betsceset/test_0_feat_overwrite_correctly_and_add_betsceset.py
@@ -171,7 +171,7 @@ class Test0FeatOverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
@@ -196,7 +196,7 @@ class Test0OverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
@@ -188,7 +188,7 @@ class Test0OverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
@@ -172,7 +172,7 @@ class Test0OverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_befsce/test_0_overwrite_correctly_and_add_befsce.py
@@ -180,7 +180,7 @@ class Test0OverwriteCorrectlyAndAddBefsce(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
@@ -196,7 +196,7 @@ class Test0OverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
@@ -172,7 +172,7 @@ class Test0OverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
@@ -188,7 +188,7 @@ class Test0OverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_and_add_betsceset/test_0_overwrite_correctly_and_add_betsceset.py
@@ -180,7 +180,7 @@ class Test0OverwriteCorrectlyAndAddBetsceset(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
@@ -171,7 +171,7 @@ class Test0OverwriteCorrectlyBefsce(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
@@ -187,7 +187,7 @@ class Test0OverwriteCorrectlyBefsce(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
@@ -195,7 +195,7 @@ class Test0OverwriteCorrectlyBefsce(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_befsce/test_0_overwrite_correctly_befsce.py
@@ -179,7 +179,7 @@ class Test0OverwriteCorrectlyBefsce(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
@@ -171,7 +171,7 @@ class Test0OverwriteCorrectlyBetsceset(Base0EnvtesterClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
@@ -195,7 +195,7 @@ class Test0OverwriteCorrectlyBetsceset(Base0EnvtesterClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
@@ -179,7 +179,7 @@ class Test0OverwriteCorrectlyBetsceset(Base0EnvtesterClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
+++ b/tests/vdevice/inheritance/test_0_overwrite_correctly_betsceset/test_0_overwrite_correctly_betsceset.py
@@ -187,7 +187,7 @@ class Test0OverwriteCorrectlyBetsceset(Base0EnvtesterClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
+++ b/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
@@ -180,7 +180,7 @@ class Test01DiffWithVdeviceAndCnns(Base01EnvtesterMethvarClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
+++ b/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
@@ -172,7 +172,7 @@ class Test01DiffWithVdeviceAndCnns(Base01EnvtesterMethvarClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
+++ b/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
@@ -196,7 +196,7 @@ class Test01DiffWithVdeviceAndCnns(Base01EnvtesterMethvarClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
+++ b/tests/vdevice/methodbased/test_01_diff_with_vdevice_and_cnns/test_01_diff_with_vdevice_and_cnns.py
@@ -188,7 +188,7 @@ class Test01DiffWithVdeviceAndCnns(Base01EnvtesterMethvarClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
+++ b/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
@@ -103,7 +103,7 @@ class Test01MethvarParamCheck(Base01EnvtesterMethvarClass):
             assert cur_setup_executor.body_result.result == ResultState.SUCCESS
             assert cur_setup_executor.teardown_result.result == ResultState.SUCCESS
 
-            for cur_scenario_executor in cur_setup_executor.scenario_executors:
+            for cur_scenario_executor in cur_setup_executor.get_scenario_executors():
                 assert cur_scenario_executor.executor_result == ResultState.SUCCESS, \
                     "the scenario executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
+++ b/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
@@ -95,7 +95,7 @@ class Test01MethvarParamCheck(Base01EnvtesterMethvarClass):
             "global executor tree body part does not set ResultState.SUCCESS"
         assert session.executor_tree.teardown_result.result == ResultState.SUCCESS, \
             "global executor tree teardown part does not set ResultState.SUCCESS"
-        for cur_setup_executor in session.executor_tree.setup_executors:
+        for cur_setup_executor in session.executor_tree.get_setup_executors():
             assert cur_setup_executor.executor_result == ResultState.SUCCESS, \
                 "the setup executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
+++ b/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
@@ -111,7 +111,7 @@ class Test01MethvarParamCheck(Base01EnvtesterMethvarClass):
                 assert cur_scenario_executor.body_result.result == ResultState.SUCCESS
                 assert cur_scenario_executor.teardown_result.result == ResultState.SUCCESS
 
-                for cur_variation_executor in cur_scenario_executor.variation_executors:
+                for cur_variation_executor in cur_scenario_executor.get_variation_executors():
                     assert cur_variation_executor.executor_result == ResultState.SUCCESS, \
                         "the variation executor does not have result SUCCESS"
 

--- a/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
+++ b/tests/vdevice/methodbased/test_01_methvar_param_check/test_01_methvar_param_check.py
@@ -119,7 +119,7 @@ class Test01MethvarParamCheck(Base01EnvtesterMethvarClass):
                     assert cur_variation_executor.body_result.result == ResultState.SUCCESS
                     assert cur_variation_executor.teardown_result.result == ResultState.SUCCESS
 
-                    for cur_testcase_executor in cur_variation_executor.testcase_executors:
+                    for cur_testcase_executor in cur_variation_executor.get_testcase_executors():
                         assert cur_testcase_executor.executor_result == ResultState.SUCCESS, \
                             "the testcase executor does not have result SUCCESS"
 

--- a/tests/vdevice/test_1_double_illegal_vdevice_mapping/test_1_double_illegal_vdevice_mapping.py
+++ b/tests/vdevice/test_1_double_illegal_vdevice_mapping/test_1_double_illegal_vdevice_mapping.py
@@ -33,5 +33,5 @@ def processed(env_dir):
     assert session.executor_tree.teardown_result.result == ResultState.NOT_RUN, \
         "global executor tree teardown part does not set ResultState.NOT_RUN"
 
-    assert len(session.executor_tree.setup_executors) == 0, \
+    assert len(session.executor_tree.get_setup_executors()) == 0, \
         "there exists some setup executor - that should not be the case"

--- a/tests/vdevice/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns.py
+++ b/tests/vdevice/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns.py
@@ -39,13 +39,14 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "not exactly one setup executor found"
-    assert session.executor_tree.setup_executors[0].base_setup_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
         "not exactly one scenario executor found"
-    assert session.executor_tree.setup_executors[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-           "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors) == 1, \
+    assert \
+        session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
+        "ScenarioAdding", "wrong scenario class was executed"
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 1, \
         "not exactly two variation executor found"

--- a/tests/vdevice/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns.py
+++ b/tests/vdevice/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns.py
@@ -43,10 +43,11 @@ def processed(env_dir):
         "not exactly one setup executor found"
     assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].get_scenario_executors()) == 1, \
         "not exactly one scenario executor found"
-    assert \
-        session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-        "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 1, \
+
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
+    assert scenario_executors[0].base_scenario_class.__class__.__name__ == \
+           "ScenarioAdding", "wrong scenario class was executed"
+    assert len(scenario_executors[0].variation_executors) == 1, \
         "not exactly two variation executor found"

--- a/tests/vdevice/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns.py
+++ b/tests/vdevice/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns/test_1_scenario_check_no_reduction_of_diff_vdevice_cnns.py
@@ -49,5 +49,5 @@ def processed(env_dir):
     scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
     assert scenario_executors[0].base_scenario_class.__class__.__name__ == \
            "ScenarioAdding", "wrong scenario class was executed"
-    assert len(scenario_executors[0].variation_executors) == 1, \
+    assert len(scenario_executors[0].get_variation_executors()) == 1, \
         "not exactly two variation executor found"

--- a/tests/vdevice/test_1_setup_check_no_reduction_of_diff_vdevice_cnns/test_1_setup_check_no_reduction_of_diff_vdevice_cnns.py
+++ b/tests/vdevice/test_1_setup_check_no_reduction_of_diff_vdevice_cnns/test_1_setup_check_no_reduction_of_diff_vdevice_cnns.py
@@ -43,10 +43,10 @@ def processed(env_dir):
         "not exactly one setup executor found"
     assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
+
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
+    assert len(scenario_executors) == 1, \
         "not exactly one scenario executor found"
-    assert \
-        session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-        "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 1, \
-        "not exactly two variation executor found"
+    assert scenario_executors[0].base_scenario_class.__class__.__name__ == "ScenarioAdding", \
+        "wrong scenario class was executed"
+    assert len(scenario_executors[0].variation_executors) == 1, "not exactly two variation executor found"

--- a/tests/vdevice/test_1_setup_check_no_reduction_of_diff_vdevice_cnns/test_1_setup_check_no_reduction_of_diff_vdevice_cnns.py
+++ b/tests/vdevice/test_1_setup_check_no_reduction_of_diff_vdevice_cnns/test_1_setup_check_no_reduction_of_diff_vdevice_cnns.py
@@ -39,13 +39,14 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()) == 1, \
         "not exactly one setup executor found"
-    assert session.executor_tree.setup_executors[0].base_setup_class.__class__.__name__ == \
+    assert session.executor_tree.get_setup_executors()[0].base_setup_class.__class__.__name__ == \
            "SetupPythonAdd", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors) == 1, \
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1, \
         "not exactly one scenario executor found"
-    assert session.executor_tree.setup_executors[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
-           "ScenarioAdding", "wrong scenario class was executed"
-    assert len(session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors) == 1, \
+    assert \
+        session.executor_tree.get_setup_executors()[0].scenario_executors[0].base_scenario_class.__class__.__name__ == \
+        "ScenarioAdding", "wrong scenario class was executed"
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 1, \
         "not exactly two variation executor found"

--- a/tests/vdevice/test_1_setup_check_no_reduction_of_diff_vdevice_cnns/test_1_setup_check_no_reduction_of_diff_vdevice_cnns.py
+++ b/tests/vdevice/test_1_setup_check_no_reduction_of_diff_vdevice_cnns/test_1_setup_check_no_reduction_of_diff_vdevice_cnns.py
@@ -49,4 +49,4 @@ def processed(env_dir):
         "not exactly one scenario executor found"
     assert scenario_executors[0].base_scenario_class.__class__.__name__ == "ScenarioAdding", \
         "wrong scenario class was executed"
-    assert len(scenario_executors[0].variation_executors) == 1, "not exactly two variation executor found"
+    assert len(scenario_executors[0].get_variation_executors()) == 1, "not exactly two variation executor found"

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
@@ -32,13 +32,13 @@ def processed(env_dir):
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
     assert len(session.executor_tree.get_setup_executors()) == 1
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1
-    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 2
-    for cur_variation_executor in \
-            session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors:
+
+    scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
+    assert len(scenario_executors) == 1
+    assert len(scenario_executors[0].variation_executors) == 2
+    for cur_variation_executor in scenario_executors[0].variation_executors:
         all_setup_devices = [cur_device.__name__ for cur_device in cur_variation_executor.base_device_mapping.values()]
         assert "Calculator1" in all_setup_devices, \
             "can not find the expected `Calculator` setup device in mapped-devices"
         assert "Calculator2" not in all_setup_devices, \
             "`Calculator2` should not be contained in mapped-devices"
-

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
@@ -31,10 +31,11 @@ def processed(env_dir):
 
     assert session.executor_tree.executor_result == ResultState.SUCCESS, \
         "test session does not terminates with success"
-    assert len(session.executor_tree.setup_executors) == 1
-    assert len(session.executor_tree.setup_executors[0].scenario_executors) == 1
-    assert len(session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors) == 2
-    for cur_variation_executor in session.executor_tree.setup_executors[0].scenario_executors[0].variation_executors:
+    assert len(session.executor_tree.get_setup_executors()) == 1
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors) == 1
+    assert len(session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors) == 2
+    for cur_variation_executor in \
+            session.executor_tree.get_setup_executors()[0].scenario_executors[0].variation_executors:
         all_setup_devices = [cur_device.__name__ for cur_device in cur_variation_executor.base_device_mapping.values()]
         assert "Calculator1" in all_setup_devices, \
             "can not find the expected `Calculator` setup device in mapped-devices"

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
@@ -35,8 +35,8 @@ def processed(env_dir):
 
     scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
     assert len(scenario_executors) == 1
-    assert len(scenario_executors[0].variation_executors) == 2
-    for cur_variation_executor in scenario_executors[0].variation_executors:
+    assert len(scenario_executors[0].get_variation_executors()) == 2
+    for cur_variation_executor in scenario_executors[0].get_variation_executors():
         all_setup_devices = [cur_device.__name__ for cur_device in cur_variation_executor.base_device_mapping.values()]
         assert "Calculator1" in all_setup_devices, \
             "can not find the expected `Calculator` setup device in mapped-devices"


### PR DESCRIPTION
This PR refactors the properties `executor_tree.setup_executors`, `setup_executor.scenario_executors`, `scenario_executor.variation_executors` and `variation_executor.testcase_executors` to methods `executor_tree.get_setup_executors()`, `setup_executor.get_scenario_executors()`, `scenario_executor.get_variation_executors()` and `variation_executor.get_testcase_executors()`.

It prepares the environment for the coming argument --show-discarded, that should display information about discarded variations.