### PR TITLE
add new command line argument `--show-discarded`

### DIFF
--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -330,8 +330,8 @@ class BalderSession:
             print(f"  resolve them to {len(self.executor_tree.get_all_variation_executors())} mapping candidates")
             print("")
             if not self.resolve_only:
-                self.executor_tree.execute()
+                self.executor_tree.execute(show_discarded=self.show_discarded)
             else:
-                self.executor_tree.print_tree()
+                self.executor_tree.print_tree(show_discarded=self.show_discarded)
 
         self.plugin_manager.execute_session_finished(self.executor_tree)

--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -327,7 +327,10 @@ class BalderSession:
         if not self.collect_only:
             self.solve()
             self.create_executor_tree()
-            print(f"  resolve them to {len(self.executor_tree.get_all_variation_executors())} mapping candidates")
+            count_valid = len(self.executor_tree.get_all_variation_executors())
+            count_discarded = len(self.executor_tree.get_all_variation_executors(return_discarded=True)) - count_valid
+            addon_text = f" ({count_discarded} discarded)" if self.show_discarded else ""
+            print(f"  resolve them to {count_valid} valid variations{addon_text}")
             print("")
             if not self.resolve_only:
                 self.executor_tree.execute(show_discarded=self.show_discarded)

--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -305,12 +305,6 @@ class BalderSession:
         self.executor_tree = self.solver.get_executor_tree(plugin_manager=self.plugin_manager)
         self.plugin_manager.execute_filter_executor_tree(executor_tree=self.executor_tree)
 
-    def execute_executor_tree(self):
-        """
-        This method executes the :class:`ExecutorTree`.
-        """
-        self.executor_tree.execute()
-
     def run(self):
         """
         This method executes the whole session
@@ -336,7 +330,7 @@ class BalderSession:
             print(f"  resolve them to {len(self.executor_tree.get_all_variation_executors())} mapping candidates")
             print("")
             if not self.resolve_only:
-                self.execute_executor_tree()
+                self.executor_tree.execute()
             else:
                 self.executor_tree.print_tree()
 

--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -60,6 +60,8 @@ class BalderSession:
         self.collect_only: Union[bool, None] = None
         #: specifies that the tests should only be collected and resolved but not executed
         self.resolve_only: Union[bool, None] = None
+        #: specifies that all discarded variations should be printed (with information why they were discarded)
+        self.show_discarded: Union[bool, None] = None
         #: contains a number of :class:`Setup` class strings that should only be considered for the execution
         self.only_with_setup: Union[List[str], None] = None
         #: contains a number of :class:`Scenario` class strings that should only be considered for the execution
@@ -247,6 +249,10 @@ class BalderSession:
             help="specifies that the tests are only collected and resolved but not executed")
 
         self.cmd_arg_parser.add_argument(
+            '--show-discarded', action='store_true',
+            help="specifies that all discarded variations should be printed (with information why they were discarded)")
+
+        self.cmd_arg_parser.add_argument(
             '--only-with-setup', nargs="*",
             help="defines a number of Setup classes which should only be considered for the execution")
 
@@ -270,6 +276,7 @@ class BalderSession:
         self.working_dir = self.parsed_args.working_dir
         self.collect_only = self.parsed_args.collect_only
         self.resolve_only = self.parsed_args.resolve_only
+        self.show_discarded = self.parsed_args.show_discarded
         self.only_with_setup = self.parsed_args.only_with_setup
         self.only_with_scenario = self.parsed_args.only_with_scenario
         self.force_covered_by_duplicates = self.parsed_args.force_covered_by_duplicates

--- a/src/_balder/executor/basic_executor.py
+++ b/src/_balder/executor/basic_executor.py
@@ -137,7 +137,7 @@ class BasicExecutor(ABC):
             if isinstance(cur_child_executor.body_result, TestcaseResult):
                 cur_child_executor.body_result.set_result(result=value, exception=None)
 
-    def has_runnable_elements(self) -> bool:
+    def has_runnable_tests(self) -> bool:
         """
         This method returns true if this executor element is runnable. The method returns true if this element has
         `prev_mark=RUNNABLE` and minimum one of its children has `prev_mark=RUNNABLE` too.
@@ -145,7 +145,7 @@ class BasicExecutor(ABC):
         if self.prev_mark != PreviousExecutorMark.RUNNABLE:
             return False
         for cur_child in self.all_child_executors:
-            if cur_child.has_runnable_elements():
+            if cur_child.has_runnable_tests():
                 return True
         return False
 
@@ -165,7 +165,7 @@ class BasicExecutor(ABC):
         # only go through cur_executor == ExecutorTree (do not iterate with this object)
         while cur_executor.parent_executor is not None:
             if isinstance(cur_executor.base_instance, with_type):
-                if not only_runnable_elements or cur_executor.has_runnable_elements():
+                if not only_runnable_elements or cur_executor.has_runnable_tests():
                     return [cur_executor.base_instance]
             cur_executor = cur_executor.parent_executor
 

--- a/src/_balder/executor/basic_executor.py
+++ b/src/_balder/executor/basic_executor.py
@@ -145,7 +145,7 @@ class BasicExecutor(ABC):
         if self.prev_mark != PreviousExecutorMark.RUNNABLE:
             return False
         for cur_child in self.all_child_executors:
-            if cur_child.prev_mark == PreviousExecutorMark.RUNNABLE:
+            if cur_child.has_runnable_elements():
                 return True
         return False
 

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -58,7 +58,7 @@ class ExecutorTree(BasicExecutor):
 
     def _body_execution(self):
         for cur_setup_executor in self.get_setup_executors():
-            if cur_setup_executor.has_runnable_elements():
+            if cur_setup_executor.has_runnable_tests():
                 cur_setup_executor.execute()
             elif cur_setup_executor.prev_mark == PreviousExecutorMark.SKIP:
                 cur_setup_executor.set_result_for_whole_branch(ResultState.SKIP)
@@ -153,7 +153,7 @@ class ExecutorTree(BasicExecutor):
 
         print_line(start_text)
         # check if there exists runnable elements
-        runnables = [cur_exec.has_runnable_elements() for cur_exec in self.get_setup_executors()]
+        runnables = [cur_exec.has_runnable_tests() for cur_exec in self.get_setup_executors()]
         one_or_more_runnable_setups = None if len(runnables) == 0 else max(runnables)
         if one_or_more_runnable_setups:
             super().execute()

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -86,13 +86,13 @@ class ExecutorTree(BasicExecutor):
             all_scenario_executor += cur_setup_executor.get_scenario_executors()
         return all_scenario_executor
 
-    def get_all_variation_executors(self) -> List[VariationExecutor]:
+    def get_all_variation_executors(self, return_discarded=False) -> List[VariationExecutor]:
         """
         returns a list with all variation executors
         """
         all_variation_executor = []
         for cur_scenario_executor in self.get_all_scenario_executors():
-            all_variation_executor += cur_scenario_executor.get_variation_executors()
+            all_variation_executor += cur_scenario_executor.get_variation_executors(return_discarded=return_discarded)
         return all_variation_executor
 
     def get_all_testcase_executors(self) -> List[TestcaseExecutor]:

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -91,7 +91,7 @@ class ScenarioExecutor(BasicExecutor):
 
     def _body_execution(self):
         for cur_variation_executor in self.get_variation_executors():
-            if cur_variation_executor.has_runnable_elements():
+            if cur_variation_executor.has_runnable_tests():
                 cur_variation_executor.execute()
             elif cur_variation_executor.prev_mark == PreviousExecutorMark.SKIP:
                 cur_variation_executor.set_result_for_whole_branch(ResultState.SKIP)

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -86,13 +86,13 @@ class ScenarioExecutor(BasicExecutor):
 
     # ---------------------------------- PROTECTED METHODS -------------------------------------------------------------
 
-    def _prepare_execution(self):
+    def _prepare_execution(self, show_discarded):
         print(f"  SCENARIO {self.base_scenario_class.__class__.__name__}")
 
-    def _body_execution(self):
-        for cur_variation_executor in self.get_variation_executors():
-            if cur_variation_executor.has_runnable_tests():
-                cur_variation_executor.execute()
+    def _body_execution(self, show_discarded):
+        for cur_variation_executor in self.get_variation_executors(return_discarded=show_discarded):
+            if cur_variation_executor.has_runnable_tests(show_discarded):
+                cur_variation_executor.execute(show_discarded=show_discarded)
             elif cur_variation_executor.prev_mark == PreviousExecutorMark.SKIP:
                 cur_variation_executor.set_result_for_whole_branch(ResultState.SKIP)
             elif cur_variation_executor.prev_mark == PreviousExecutorMark.COVERED_BY:
@@ -100,13 +100,20 @@ class ScenarioExecutor(BasicExecutor):
             else:
                 cur_variation_executor.set_result_for_whole_branch(ResultState.NOT_RUN)
 
-    def _cleanup_execution(self):
+    def _cleanup_execution(self, show_discarded):
         pass
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
-    def get_variation_executors(self) -> List[VariationExecutor]:
-        """returns all variation executors that are child executor of this scenario executor"""
+    def get_variation_executors(self, return_discarded=False) -> List[VariationExecutor]:
+        """
+        :param return_discarded: True if the method should return discarded variations too
+
+        :return: returns all variation executors that are child executor of this scenario executor
+        """
+        if not return_discarded:
+            return [cur_executor for cur_executor in self._variation_executors
+                    if cur_executor.prev_mark != PreviousExecutorMark.DISCARDED]
         return self._variation_executors
 
     def cleanup_empty_executor_branches(self):

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -70,7 +70,7 @@ class SetupExecutor(BasicExecutor):
 
     def _body_execution(self):
         for cur_scenario_executor in self.get_scenario_executors():
-            if cur_scenario_executor.has_runnable_elements():
+            if cur_scenario_executor.has_runnable_tests():
                 cur_scenario_executor.execute()
             elif cur_scenario_executor.prev_mark == PreviousExecutorMark.SKIP:
                 cur_scenario_executor.set_result_for_whole_branch(ResultState.SKIP)

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -65,13 +65,13 @@ class SetupExecutor(BasicExecutor):
 
     # ---------------------------------- PROTECTED METHODS -------------------------------------------------------------
 
-    def _prepare_execution(self):
+    def _prepare_execution(self, show_discarded):
         print(f"SETUP {self.base_setup_class.__class__.__name__}")
 
-    def _body_execution(self):
+    def _body_execution(self, show_discarded):
         for cur_scenario_executor in self.get_scenario_executors():
-            if cur_scenario_executor.has_runnable_tests():
-                cur_scenario_executor.execute()
+            if cur_scenario_executor.has_runnable_tests(consider_discarded_too=show_discarded):
+                cur_scenario_executor.execute(show_discarded=show_discarded)
             elif cur_scenario_executor.prev_mark == PreviousExecutorMark.SKIP:
                 cur_scenario_executor.set_result_for_whole_branch(ResultState.SKIP)
             elif cur_scenario_executor.prev_mark == PreviousExecutorMark.COVERED_BY:
@@ -79,7 +79,7 @@ class SetupExecutor(BasicExecutor):
             else:
                 cur_scenario_executor.set_result_for_whole_branch(ResultState.NOT_RUN)
 
-    def _cleanup_execution(self):
+    def _cleanup_execution(self, show_discarded):
         pass
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -114,7 +114,7 @@ class TestcaseExecutor(BasicExecutor):
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
-    def has_runnable_elements(self) -> bool:
+    def has_runnable_tests(self) -> bool:
         return self.prev_mark == PreviousExecutorMark.RUNNABLE
 
     def should_run(self):

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -76,7 +76,7 @@ class TestcaseExecutor(BasicExecutor):
 
     # ---------------------------------- PROTECTED METHODS -------------------------------------------------------------
 
-    def _prepare_execution(self):
+    def _prepare_execution(self, show_discarded):
         print(f"      TEST {self.base_testcase_callable.__qualname__} ", end='')
         if self.should_be_skipped():
             self.body_result.set_result(ResultState.SKIP)
@@ -84,7 +84,7 @@ class TestcaseExecutor(BasicExecutor):
             print("[S]")
             return
 
-    def _body_execution(self):
+    def _body_execution(self, show_discarded):
         start_time = time.perf_counter()
         try:
             _, func_type = inspect_method(self.base_testcase_callable)
@@ -109,7 +109,7 @@ class TestcaseExecutor(BasicExecutor):
             self.body_result.set_result(ResultState.FAILURE, exc)
         self.test_execution_time_sec = time.perf_counter() - start_time
 
-    def _cleanup_execution(self):
+    def _cleanup_execution(self, show_discarded):
         print(f"[{self.body_result.get_result_as_char()}]")
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -114,9 +114,6 @@ class TestcaseExecutor(BasicExecutor):
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
-    def has_runnable_tests(self) -> bool:
-        return self.prev_mark == PreviousExecutorMark.RUNNABLE
-
     def should_run(self):
         """returns true if the testcase should be executed (defined in scenario)"""
         if self.base_testcase_callable in self.parent_executor.parent_executor.all_run_tests:

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -143,7 +143,7 @@ class VariationExecutor(BasicExecutor):
 
     def _body_execution(self):
         for cur_testcase_executor in self.get_testcase_executors():
-            if cur_testcase_executor.has_runnable_elements():
+            if cur_testcase_executor.has_runnable_tests():
 
                 cur_testcase_executor.execute()
             elif cur_testcase_executor.prev_mark == PreviousExecutorMark.SKIP:

--- a/src/_balder/previous_executor_mark.py
+++ b/src/_balder/previous_executor_mark.py
@@ -18,3 +18,6 @@ class PreviousExecutorMark(Enum):
 
     #: this marks that the element should be ignored from the executor mechanism
     IGNORE = -1
+
+    #: this marks that the element was already discarded because its variation is not applicable
+    DISCARDED = -2

--- a/src/_balder/solver.py
+++ b/src/_balder/solver.py
@@ -198,21 +198,19 @@ class Solver:
             if variation_executor is None:
                 # variation is not available -> create new VariationExecutor
                 variation_executor = VariationExecutor(device_mapping=cur_device_mapping, parent=scenario_executor)
+                variation_executor.verify_applicability()
 
-                # only add if the features for this device mapping matches
-                if variation_executor.can_be_applied():
-                    scenario_executor.add_variation_executor(variation_executor)
+                scenario_executor.add_variation_executor(variation_executor)
+                for cur_testcase in ScenarioController.get_for(cur_scenario).get_all_test_methods():
+                    cur_testcase_executor = TestcaseExecutor(cur_testcase, parent=variation_executor)
+                    variation_executor.add_testcase_executor(cur_testcase_executor)
 
-                    for cur_testcase in ScenarioController.get_for(cur_scenario).get_all_test_methods():
-                        cur_testcase_executor = TestcaseExecutor(cur_testcase, parent=variation_executor)
-                        variation_executor.add_testcase_executor(cur_testcase_executor)
-
-                        # determine prev_mark IGNORE/SKIP for the testcase
-                        if cur_testcase_executor.should_be_skipped():
-                            cur_testcase_executor.prev_mark = PreviousExecutorMark.SKIP
-                        # always overwrite if it should be ignored
-                        if cur_testcase_executor.should_be_ignored():
-                            cur_testcase_executor.prev_mark = PreviousExecutorMark.IGNORE
+                    # determine prev_mark IGNORE/SKIP for the testcase
+                    if cur_testcase_executor.should_be_skipped():
+                        cur_testcase_executor.prev_mark = PreviousExecutorMark.SKIP
+                    # always overwrite if it should be ignored
+                    if cur_testcase_executor.should_be_ignored():
+                        cur_testcase_executor.prev_mark = PreviousExecutorMark.IGNORE
 
         # now filter all elements that have no child elements
         #   -> these are items that have no valid matching, because no variation can be applied for it (there are no


### PR DESCRIPTION
This PR adds a new command line argument `--show-discarded`, that will print the discarded variations with a description why it was discarded.

Executing Balder with `balder --show-discarded`:

```
+----------------------------------------------------------------------------------------------------------------------+
| BALDER Testsystem                                                                                                    |
|  python version 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] | balder version 0.1.0b1.dev109+gbc7e910           |
+----------------------------------------------------------------------------------------------------------------------+
Collect 2 Setups and 2 Scenarios
  resolve them to 2 valid variations (2 discarded)

================================================== START TESTSESSION ===================================================
SETUP SetupA
  SCENARIO ScenarioA
    VARIATION ScenarioA.ScenarioDevice1:SetupA.SetupDevice1 | ScenarioA.ScenarioDevice2:SetupA.SetupDevice2
      TEST ScenarioA.test_a_1 [.]
      TEST ScenarioA.test_a_2 [.]
    VARIATION ScenarioA.ScenarioDevice1:SetupA.SetupDevice2 | ScenarioA.ScenarioDevice2:SetupA.SetupDevice1
      DISCARDED BECAUSE `this variation can not be applied because there was no setup feature implementation of `FeatureI` (used by scenario device `ScenarioDevice1`) in setup device `SetupDevice2``
SETUP SetupB
  SCENARIO ScenarioB
    VARIATION ScenarioB.ScenarioDevice3:SetupB.SetupDevice3 | ScenarioB.ScenarioDevice4:SetupB.SetupDevice4
      TEST ScenarioB.test_b_1 [.]
      TEST ScenarioB.test_b_2 [.]
    VARIATION ScenarioB.ScenarioDevice3:SetupB.SetupDevice4 | ScenarioB.ScenarioDevice4:SetupB.SetupDevice3
      DISCARDED BECAUSE `this variation can not be applied because there was no setup feature implementation of `FeatureIII` (used by scenario device `ScenarioDevice3`) in setup device `SetupDevice4``
================================================== FINISH TESTSESSION ==================================================
TOTAL NOT_RUN: 0 | TOTAL FAILURE: 0 | TOTAL ERROR: 0 | TOTAL SUCCESS: 4 | TOTAL SKIP: 0 | TOTAL COVERED_BY: 0

``` 

It can also be executed in resolve-only mode `balder --resolve-only --show-discarded`:

```
+----------------------------------------------------------------------------------------------------------------------+
| BALDER Testsystem                                                                                                    |
|  python version 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] | balder version 0.1.0b1.dev109+gbc7e910           |
+----------------------------------------------------------------------------------------------------------------------+
Collect 2 Setups and 2 Scenarios
  resolve them to 2 valid variations (2 discarded)

RESOLVING OVERVIEW

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ [APPLICABLE] Scenario `ScenarioA` <-> Setup `SetupA`
+    ScenarioA.ScenarioDevice1 = SetupA.SetupDevice1
+    ScenarioA.ScenarioDevice2 = SetupA.SetupDevice2
+    -> Testcase<ScenarioA.test_a_1>
+    -> Testcase<ScenarioA.test_a_2>
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
X [DISCARDED]  Scenario `ScenarioA` <-> Setup `SetupA`
X    ScenarioA.ScenarioDevice1 = SetupA.SetupDevice2
X    ScenarioA.ScenarioDevice2 = SetupA.SetupDevice1
X    -> Testcase<ScenarioA.test_a_1>
X    -> Testcase<ScenarioA.test_a_2>
X
X    DISCARDED BECAUSE `this variation can not be applied because there was no setup feature implementation of `FeatureI` (used by scenario device `ScenarioDevice1`) in setup device `SetupDevice2``
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ [APPLICABLE] Scenario `ScenarioB` <-> Setup `SetupB`
+    ScenarioB.ScenarioDevice3 = SetupB.SetupDevice3
+    ScenarioB.ScenarioDevice4 = SetupB.SetupDevice4
+    -> Testcase<ScenarioB.test_b_1>
+    -> Testcase<ScenarioB.test_b_2>
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
X [DISCARDED]  Scenario `ScenarioB` <-> Setup `SetupB`
X    ScenarioB.ScenarioDevice3 = SetupB.SetupDevice4
X    ScenarioB.ScenarioDevice4 = SetupB.SetupDevice3
X    -> Testcase<ScenarioB.test_b_1>
X    -> Testcase<ScenarioB.test_b_2>
X
X    DISCARDED BECAUSE `this variation can not be applied because there was no setup feature implementation of `FeatureIII` (used by scenario device `ScenarioDevice3`) in setup device `SetupDevice4``
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

```

Further TODOs: The discarded messages are the exception argument for all `NotApplicableVariationException`. These information has to be optimized. 