### PR TITLE
docs: rework the most important content of basic docs

### DIFF
--- a/doc/source/basics/balderhub.rst
+++ b/doc/source/basics/balderhub.rst
@@ -7,8 +7,8 @@ BalderHub - the share place of tests
 
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
-Balder' grand vision is to create a open-source, share place for testing-projects. We call them **BalderHub** packages.
-These packages are normal python packages. You can easily install them like normal python package and simply include
+Balder' grand vision is to create a shared place for open-source testing-projects. We call them **BalderHub** packages.
+These packages are normal python packages. You can easily install them like normal and simply include
 them into your specific project. That allows you to reuse scenario and feature implementation by your own. You only have
 to provide your custom implementation that really depends on your device, but not the general test logic.
 
@@ -58,17 +58,15 @@ Which scenarios are used?
 
 If you want to use a scenario of a BalderHub project, you have to create a new scenario class in your project and
 inherit from the installed package. For example, if you want to use the scenario ``ScenarioExample`` of the
-project ``balderhub-example``, you have to  create a new scenario file in your project and inherit from it:
+project ``balderhub-example``, you have to create a new scenario file in your project and imports the BalderHub
+scenario:
 
 .. code-block:: python
 
     # file tests/scenarios/scenario_for_me.py
     from balderhub.example.scenarios import ScenarioExample
 
-    class ScenarioForMe(ScenarioExample):
-        pass
-
-With that the whole scenario will be active and all test methods of the inherited scenario ``ScenarioExample`` will be
+With that the whole scenario will be active and all test methods of the scenario ``ScenarioExample`` will be
 used. Of course your setup-devices have to implement the features of the scenario-devices too.
 
 ..

--- a/doc/source/basics/connections.rst
+++ b/doc/source/basics/connections.rst
@@ -215,7 +215,7 @@ Balder provides an global connection tree. This tree is already specified for al
 Overwrite the default global tree
 ---------------------------------
 
-Per default, the ``@balder.insert_into_tree(..)`` decorator inserted the connection in the global connection tree. If
+Per default, the ``@balder.insert_into_tree(..)`` decorator inserts the connection in the global connection tree. If
 you want to use another connection tree, you can specify the ``tree_name=".."`` argument in the
 ``@balder.insert_into_tree(..)``. This allows to specify an complete own connection tree by your own.
 

--- a/doc/source/basics/execution_mechanism.rst
+++ b/doc/source/basics/execution_mechanism.rst
@@ -1,4 +1,4 @@
-Balder Execution mechanism
+Balder execution mechanism
 **************************
 
 .. important::
@@ -71,7 +71,7 @@ Only for classes that meet all these criteria, Balder will acknowledge these cla
 them to the internal collection of executable scenarios.
 
 In the same way, Balder searches for scenarios, it will do that for setups. These setups have to be in files that have
-the name ``setup_*.py` and whose classes have the name ``Setup*`` and are child classes of :class:`Setup`.
+the name ``setup_*.py`` and whose classes have the name ``Setup*`` and are child classes of :class:`Setup`.
 
 .. note::
     Note that every ``.py`` file will be loaded that starts with ``scenario_*`` or ``setup_*``.
@@ -435,11 +435,11 @@ Using Fixtures
 ==============
 
 Balder also supports the concept of fixtures. Fixtures are functions (or methods) that will be executed to prepare or
-for follow-up devices or other things before or after a testcase or a scenario/setup will be executed.
+clean-up devices or other things before or after a testcase or a scenario/setup will be executed.
 
-Fixtures can be divided into two areas. First they have a **definition-scope**, that describes where the fixture is
-defined. In addition to that, they have a **execution-level**, that defines at which point the fixture should be
-executed.
+Fixtures have two main properties that determine the behaviour and validity of a fixture. First they have a
+**definition-scope**, that describes where the fixture is defined. In addition to that, they have a **execution-level**,
+that defines at which point the fixture should be executed.
 
 The execution-level
 -------------------
@@ -601,4 +601,4 @@ provide a method here too:
             yield
             self.ClientDevice.req.logout()
 
-For more about features, take a look :ref:`here <Features>`.
+For more about fixtures, take a look :ref:`here <Fixtures>`.

--- a/doc/source/basics/features.rst
+++ b/doc/source/basics/features.rst
@@ -126,10 +126,10 @@ Autonomous-Features
 Autonomous-Features are a special type of :class:`Feature` classes. These features has no own methods or
 properties, they are only used to say:
 
-*This device has the feature ``IsRedFeature``*
+*This device has the feature* ``IsRedFeature``
 
 So we want to filter them, because we only want a match with a device that has the same feature, but we can't or
-don't want to influence or interact with this device over the autonomous :class:`.Feature`.
+don't want to influence or interact with this device over the autonomous :class:`Feature`.
 
 The definition for such a autonomous feature, is really easy:
 
@@ -162,10 +162,10 @@ recommend that you assign it to a property name with a beginning underscore:
             _pipe_mirror = PipeMirrorAutonomousFeature()
 
 This example shows a good real world example. Imagine, you want to test if the ``ReceiverDevice`` can mirror a
-message you have send with another ``SenderDevice``. Physically we can only influence the ``SenderDevice``, but have
+message you have send with another ``SenderDevice``. Picture that we can only influence the ``SenderDevice``, but have
 no possibilities to interact with the ``ReceiverDevice``. We only know, that this device can mirror the messages
-we sent. In this case you can use a Autonomous-Feature, because you know that the device must have it, but you
-can not influence it.
+we sent. Here we can use a so-called Autonomous-Feature for our ``ReceiverDevice``, because we know that the device
+must have it, but you can not influence it.
 
 Your setup can use the same object. You don't have to overwrite it, because you don't want to add functionality
 to it, like we have done with the other features before. So we simply reuse this feature from scenario level in our
@@ -185,9 +185,8 @@ setup:
 
         @balder.connect(PipeDevice, over_connection=PipeConnection)
         class MirrorDevice(balder.Device):
-            # autonomous-device - nothing to implement
-            class PipeMirrorFeature(setup_my_features.PipeMirrorAutonomousFeature):
-                pass
+            # autonomous-device
+            mirror = setup_my_features.PipeMirrorAutonomousFeature()
 
 
 Bind features
@@ -261,8 +260,10 @@ attribute ``OtherPipeVDevice="PipeDevice2"`` to the feature constructor to defin
 
 
 .. note::
-    Often you can not access the device type objects inside the feature constructor. For this Balder also allows to use
-    simple strings, that contains the same name than the referencing device type.
+    In Python it depends on the definition order if you can reference the device inside the ``@balder.connect(..)``
+    decorator. If the device is defined above your decorator, it is possible, otherwise not. For this, Balder always
+    allows to provide the device as string too.
+
 
 You can do this with different devices that could stand for different usages of this feature. So you can also add
 the ``PipeSendReceive`` feature of the ``PipeDevice2`` should use a vdevice-device mapping with the ``PipeDevice1`` too:

--- a/doc/source/basics/fixtures.rst
+++ b/doc/source/basics/fixtures.rst
@@ -8,10 +8,9 @@ Fixtures
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
 Fixtures are functions or methods that ensure that code is executed before or after specific times of a test run.
-Fixtures can be executed at different times (**execution-level**) and can be defined on different positions
-(**definition-scope**). The order in which these fixtures will be executed, depends on the definition position (in which
-module the code is implemented) and often also depending on some chained dependency between them. You can learn more
-about this in this section.
+Fixtures can be executed at different times in the Balder process (**execution-level**) and can be defined on different
+positions (**definition-scope**). The order, in which these fixtures will be executed, can be influenced by chained
+dependencies too. You can learn more about this in this section.
 
 A simple fixture
 ================
@@ -77,7 +76,7 @@ uses the ``ScenarioB`` this behavior will change. In this case our fixture won't
 **definition-scope** is not active (fixture is defined in the not executed ``ScenarioA``).
 
 You can find more detailed information about the **definition-scope** at the
-:ref:`Definition-Scopes <Definition-Scopes>`.
+:ref:`Definition-Scopes <Definition-Scope possibilities>`.
 
 Fixture ordering
 ----------------
@@ -169,7 +168,7 @@ directly be used there. This example would produce the following output:
 
 You can also refer fixtures from another **execution-level** or **definition-scope**, but you have to secure that your
 referred fixture runs before the fixture that references it. For more information about the referencing of fixtures and
-the related ordering, see :ref:`Order or/and referencing fixtures`.
+the related ordering, see :ref:`reference fixtures`.
 
 Execution-Level possibilities
 =============================
@@ -203,8 +202,8 @@ execution. The following table shows all possible **execution-level** attributes
 |                        | that is in the defined **definition-scope**.                                                |
 +------------------------+---------------------------------------------------------------------------------------------+
 
-Definition-Scopes
-=================
+Definition-Scope possibilities
+==============================
 
 Balder has three different **definition-scopes**. These scopes define the validity of the fixtures.
 
@@ -233,14 +232,14 @@ The following table shows these scopes:
 |                        |                        | currently active in the test run.                                  |
 +------------------------+------------------------+--------------------------------------------------------------------+
 
-Order or/and referencing fixtures
-=================================
+Reference fixtures
+==================
 
-As mentioned above, Balder can referencing fixtures among each other.
+As mentioned above, Balder can reference fixtures among each other.
 
-Sometimes you want to use the values of some fixtures into testcases or other fixtures. For example if you prepare an
+Sometimes you want to use the values of some fixtures in testcases or other fixtures. For example if you prepare an
 object in a fixture you maybe want to use this object in another fixture or in your testcase too. This can be
-realized in Balder by simply referencing fixtures throw method/function attributes.
+realized in Balder by simply referencing fixtures through method/function attributes.
 
 .. code-block:: py
 
@@ -493,7 +492,7 @@ for the referenced fixture. In this case here, the next fixture with the referen
 
     print_it from scenario: calculation is 15
 
-Special case: Unclear-Setup_Scoped_Fixture-Reference problematic
+Special case: Unclear-Setup-Scoped-Fixture-Reference problematic
 ----------------------------------------------------------------
 
 There is one single case, you should be aware with. If you want to reference a session-fixture

--- a/doc/source/basics/vdevices.rst
+++ b/doc/source/basics/vdevices.rst
@@ -7,11 +7,15 @@ VDevices and method-variations
 
     Please note that this part of the documentation is not yet finished. It will still be revised and updated.
 
-During the development of :ref:`Features` you might have noticed, that you require some information from other devices.
+In many circumstances, it can be helpful, that you are able to access the :ref:`Features` of other :ref:`Devices`
+inside a feature. This allows you to get information from outside the feature and also allows you to definite the
+expected outside environment in features too.
+
 For example if you have a ``LoadSiteFeature``, which allows to load a website or a ``SendMessageFeature``, which allows
 to send a message *to another device*, you need some information about this other device.
 
-Of course, you can think about to provide the data through a method argument, like showing in the following example:
+One possibility to get data from one device to another is the providing of data through a method argument, like shown
+in the following example:
 
 .. code-block:: python
 
@@ -38,9 +42,12 @@ scope. Actually it would be enough if the feature gets access to the other devic
 vDevices
 ========
 
-A vDevice is a inner-feature device that describes a possible other device this feature interacts with. You simply
-create a vDevice, describe which features it should have (by instantiating them like it is done with normal devices) and
-use them. All other things will be automatically managed from Balder.
+A vDevice is a device-like class that describes a virtual device this feature interacts with. It is defined as an inner
+class of a feature which is a subclass of :class:`VDevice`. Balder will ensure that in case you are using this feature
+inside an scenario/setup, a real device (which implements at least the features of your VDevice) is mapped to it.
+
+You simply create a vDevice, describe which features it should have (by instantiating them like it is done with normal
+devices) and use them. All other things will be automatically managed from Balder.
 
 Let's go back to the example from earlier. Instead of giving the attribute as method parameters, you can create a
 vDevice that uses the ``HttpServerFeature``. This allows you to access the properties and methods of the


### PR DESCRIPTION
This PR fixes some typings and some mistakes in the documentation section `Basic Guides`