### PR TITLE
set `return_discarded` parameter to True in method `cleanup_empty_executor_branches`

### DIFF
--- a/src/_balder/balder_session.py
+++ b/src/_balder/balder_session.py
@@ -302,7 +302,8 @@ class BalderSession:
         .. note::
             Note that the method creates an :class:`ExecutorTree`, that hasn't to be completely resolved yet.
         """
-        self.executor_tree = self.solver.get_executor_tree(plugin_manager=self.plugin_manager)
+        self.executor_tree = self.solver.get_executor_tree(plugin_manager=self.plugin_manager,
+                                                           add_discarded=self.show_discarded)
         self.plugin_manager.execute_filter_executor_tree(executor_tree=self.executor_tree)
 
     def run(self):

--- a/src/_balder/executor/basic_executor.py
+++ b/src/_balder/executor/basic_executor.py
@@ -193,10 +193,12 @@ class BasicExecutor(ABC):
         return list(set(result))
 
     @abstractmethod
-    def cleanup_empty_executor_branches(self):
+    def cleanup_empty_executor_branches(self, consider_discarded=False):
         """
         This method searches the whole tree and removes branches where an executor item has no own children. It can
         remove these branches, because they have no valid matchings.
+
+        :param consider_discarded: true if this method should consider discarded branches, otherwise False
         """
 
     def filter_tree_for_user_filters(self):

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -129,10 +129,10 @@ class ExecutorTree(BasicExecutor):
         # can not find some
         return None
 
-    def cleanup_empty_executor_branches(self):
+    def cleanup_empty_executor_branches(self, consider_discarded=False):
         to_remove_executor = []
         for cur_setup_executor in self.get_setup_executors():
-            cur_setup_executor.cleanup_empty_executor_branches()
+            cur_setup_executor.cleanup_empty_executor_branches(consider_discarded=consider_discarded)
             if len(cur_setup_executor.get_scenario_executors()) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_setup_executor)

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -116,12 +116,12 @@ class ScenarioExecutor(BasicExecutor):
                     if cur_executor.prev_mark != PreviousExecutorMark.DISCARDED]
         return self._variation_executors
 
-    def cleanup_empty_executor_branches(self):
+    def cleanup_empty_executor_branches(self, consider_discarded=False):
         """
         This method removes all sub executors that are empty and not relevant anymore.
         """
         to_remove_executor = []
-        for cur_variation_executor in self.get_variation_executors():
+        for cur_variation_executor in self.get_variation_executors(return_discarded=consider_discarded):
             if len(cur_variation_executor.get_testcase_executors()) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_variation_executor)

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -88,11 +88,11 @@ class SetupExecutor(BasicExecutor):
         """returns a list with all scenario executors that belongs to this setup executor"""
         return self._scenario_executors
 
-    def cleanup_empty_executor_branches(self):
+    def cleanup_empty_executor_branches(self, consider_discarded=False):
         to_remove_executor = []
         for cur_scenario_executor in self.get_scenario_executors():
-            cur_scenario_executor.cleanup_empty_executor_branches()
-            if len(cur_scenario_executor.get_variation_executors()) == 0:
+            cur_scenario_executor.cleanup_empty_executor_branches(consider_discarded=consider_discarded)
+            if len(cur_scenario_executor.get_variation_executors(return_discarded=consider_discarded)) == 0:
                 # remove this whole executor because it has no children anymore
                 to_remove_executor.append(cur_scenario_executor)
         for cur_scenario_executor in to_remove_executor:

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -132,7 +132,7 @@ class TestcaseExecutor(BasicExecutor):
             return True
         return False
 
-    def cleanup_empty_executor_branches(self):
+    def cleanup_empty_executor_branches(self, consider_discarded=False):
         """
         This method searches the whole tree and removes branches where an executor item has no own children. It can
         remove these branches, because they have no valid matchings.

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -483,7 +483,7 @@ class VariationExecutor(BasicExecutor):
         # can not find some
         return None
 
-    def cleanup_empty_executor_branches(self):
+    def cleanup_empty_executor_branches(self, consider_discarded=False):
         """
         This method searches the whole tree and removes branches where an executor item has no own children. It can
         remove these branches, because they have no valid matchings.

--- a/src/_balder/solver.py
+++ b/src/_balder/solver.py
@@ -170,9 +170,13 @@ class Solver:
         self._mapping = initial_mapping
         self._resolving_was_executed = True
 
-    def get_executor_tree(self, plugin_manager: PluginManager) -> ExecutorTree:  # pylint: disable=unused-argument
+    # pylint: disable-next=unused-argument
+    def get_executor_tree(self, plugin_manager: PluginManager, add_discarded=False) -> ExecutorTree:
         """
         This method builds the ExecutorTree from the resolved data and returns it
+
+        :param plugin_manager: the related plugin manager object
+        :param add_discarded: True in case discarded elements should be added to the tree, otherwise False
 
         :return: the executor tree is built on the basis of the mapping data
         """
@@ -215,7 +219,7 @@ class Solver:
         # now filter all elements that have no child elements
         #   -> these are items that have no valid matching, because no variation can be applied for it (there are no
         #      required :class:`Feature` matching or there exists no possible routing for the variation)
-        executor_tree.cleanup_empty_executor_branches()
+        executor_tree.cleanup_empty_executor_branches(consider_discarded=add_discarded)
 
         self._set_data_for_covered_by_in_tree(executor_tree=executor_tree)
 


### PR DESCRIPTION
This PR fixes an issue that will not show discarded branches (while using the `--show-discarded` argument) for setups/scenarios that have no applicable variations.