### PR TITLE
restructuring fixture management

### DIFF
--- a/src/_balder/decorator_fixture.py
+++ b/src/_balder/decorator_fixture.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 import functools
 from _balder.collector import Collector
-from _balder.fixture_manager import FixtureManager
+from _balder.fixture_execution_level import FixtureExecutionLevel
 
 
 def fixture(level: Literal['session', 'setup', 'scenario', 'variation', 'testcase']):
@@ -12,7 +12,7 @@ def fixture(level: Literal['session', 'setup', 'scenario', 'variation', 'testcas
 
     :param level: the execution level the fixture should have
     """
-    allowed_levels = FixtureManager.EXECUTION_LEVEL_ORDER
+    allowed_levels = [level.value for level in FixtureExecutionLevel]
 
     if level not in allowed_levels:
         raise ValueError(f"the value of `level` must be a `str` with one of the values `{'`, `'.join(allowed_levels)}`")

--- a/src/_balder/executor/basic_executor.py
+++ b/src/_balder/executor/basic_executor.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from _balder.setup import Setup
     from _balder.scenario import Scenario
     from _balder.fixture_manager import FixtureManager
+    from _balder.fixture_execution_level import FixtureExecutionLevel
 
 
 class BasicExecutor(ABC):
@@ -23,6 +24,7 @@ class BasicExecutor(ABC):
     executor classes, an executor forms a tree structure in which individual tests, which later on are executed, are
     assigned to individual scenarios
     """
+    fixture_execution_level: FixtureExecutionLevel = None
     # this property describes the runnable state of the executor branch before the executor is really used
     #  with this you can declare a whole branch as inactive, while the collecting process is active
     prev_mark = PreviousExecutorMark.RUNNABLE

--- a/src/_balder/executor/executor_tree.py
+++ b/src/_balder/executor/executor_tree.py
@@ -4,6 +4,7 @@ from typing import Union, List, Type, TYPE_CHECKING
 from dataclasses import fields
 from _balder.executor.setup_executor import SetupExecutor
 from _balder.executor.basic_executor import BasicExecutor
+from _balder.fixture_execution_level import FixtureExecutionLevel
 from _balder.fixture_manager import FixtureManager
 from _balder.testresult import ResultState, BranchBodyResult, ResultSummary
 from _balder.previous_executor_mark import PreviousExecutorMark
@@ -19,6 +20,7 @@ class ExecutorTree(BasicExecutor):
     """
     This class is the root object of the executor tree structure
     """
+    fixture_execution_level = FixtureExecutionLevel.SESSION
     LINE_LENGTH = 120
 
     def __init__(self, fixture_manager: FixtureManager):

--- a/src/_balder/executor/scenario_executor.py
+++ b/src/_balder/executor/scenario_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Type, Union, List, Dict, TYPE_CHECKING
 
+from _balder.fixture_execution_level import FixtureExecutionLevel
 from _balder.testresult import ResultState, BranchBodyResult
 from _balder.utils import get_class_that_defines_method
 from _balder.executor.basic_executor import BasicExecutor
@@ -18,6 +19,7 @@ class ScenarioExecutor(BasicExecutor):
     """
     A ScenarioExecutor can contain :meth:`VariationExecutor` as children.
     """
+    fixture_execution_level = FixtureExecutionLevel.SCENARIO
 
     def __init__(self, scenario: Type[Scenario], parent: SetupExecutor):
         super().__init__()

--- a/src/_balder/executor/setup_executor.py
+++ b/src/_balder/executor/setup_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Type, Union, List, TYPE_CHECKING
 
+from _balder.fixture_execution_level import FixtureExecutionLevel
 from _balder.testresult import ResultState, BranchBodyResult
 from _balder.executor.basic_executor import BasicExecutor
 from _balder.executor.scenario_executor import ScenarioExecutor
@@ -21,6 +22,7 @@ class SetupExecutor(BasicExecutor):
     A SetupExecutor is the highest branch object of an :class:`ExecutorTree`. It contains all scenarios and the
     underlying device mappings and their test cases that exist with this setup.
     """
+    fixture_execution_level = FixtureExecutionLevel.SETUP
 
     def __init__(self, setup: Type[Setup], parent: ExecutorTree):
         super().__init__()

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -4,6 +4,8 @@ from typing import List, Union, TYPE_CHECKING
 import sys
 import time
 import traceback
+
+from _balder.fixture_execution_level import FixtureExecutionLevel
 from _balder.utils import inspect_method
 from _balder.testresult import ResultState, TestcaseResult
 from _balder.executor.basic_executor import BasicExecutor
@@ -19,6 +21,7 @@ class TestcaseExecutor(BasicExecutor):
     A TestcaseExecutor class represents an actual single test that can be executed. It therefore references exactly to a
     test method of a scenario that can be executed on the specific setup this executor belongs to.
     """
+    fixture_execution_level = FixtureExecutionLevel.TESTCASE
 
     def __init__(self, testcase: callable, parent: VariationExecutor):
         super().__init__()

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 from _balder.device import Device
 from _balder.connection import Connection
+from _balder.fixture_execution_level import FixtureExecutionLevel
 from _balder.testresult import ResultState, BranchBodyResult, ResultSummary
 from _balder.executor.basic_executor import BasicExecutor
 from _balder.executor.testcase_executor import TestcaseExecutor
@@ -30,6 +31,7 @@ class VariationExecutor(BasicExecutor):
     """
     A VariationExecutor only contains :meth:`TestcaseExecutor` children.
     """
+    fixture_execution_level = FixtureExecutionLevel.VARIATION
 
     def __init__(self, device_mapping: Dict[Type[Device], Type[Device]], parent: ScenarioExecutor):
         super().__init__()

--- a/src/_balder/fixture_definition_scope.py
+++ b/src/_balder/fixture_definition_scope.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import List
+from enum import Enum
+
+
+class FixtureDefinitionScope(Enum):
+    """
+    This enum describes the definition scope of a fixture. A definition scope is the position the fixture was defined.
+    If the fixture was defined within the balderglob.py file, it has the definition-scope `GLOB`. If it is defined
+    within a scenario or setup it has the equivalent SCENARIO or SETUP scope.
+    """
+    GLOB = 'glob'
+    SETUP = 'setup'
+    SCENARIO = 'scenario'
+
+    @classmethod
+    def get_order(cls) -> List[FixtureDefinitionScope]:
+        """returns the priority order of the fixture definition scope"""
+        return [cls.GLOB, cls.SETUP, cls.SCENARIO]

--- a/src/_balder/fixture_execution_level.py
+++ b/src/_balder/fixture_execution_level.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from typing import List
+from enum import Enum
+
+
+class FixtureExecutionLevel(Enum):
+    """
+    This enum describes the fixture-execution-level of a fixture. It describes when the fixture should be executed. This
+    level will be set in the fixture decorator.
+    """
+    SESSION = 'session'
+    SETUP = 'setup'
+    SCENARIO = 'scenario'
+    VARIATION = 'variation'
+    TESTCASE = 'testcase'
+
+    @classmethod
+    def get_order(cls) -> List[FixtureExecutionLevel]:
+        """
+        returns the execution order of fixtures
+        """
+        return [cls.SESSION, cls.SETUP, cls.SCENARIO, cls.VARIATION, cls.TESTCASE]

--- a/src/_balder/fixture_metadata.py
+++ b/src/_balder/fixture_metadata.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from typing import Union, Type, Callable, Generator, TYPE_CHECKING
+import dataclasses
+
+from .utils import MethodLiteralType
+
+if TYPE_CHECKING:
+    from _balder.scenario import Scenario
+    from _balder.setup import Setup
+
+
+@dataclasses.dataclass
+class FixtureMetadata:
+    """
+    describes meta information for a fixture
+    """
+    #: the namespace where it is defined (None if it is in a balderglob file)
+    namespace: Union[None, Type[Scenario], Type[Setup]]
+    #: the type of the fixture function
+    function_type: MethodLiteralType
+    #: the fixture callable itself
+    callable: Callable
+    #: the generator object (if the fixture is not a generator, it holds an empty generator)
+    generator: Generator
+    #: result according to the fixture's construction code (will be cleaned after it leaves a level)
+    retval: object

--- a/src/_balder/solver.py
+++ b/src/_balder/solver.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Tuple, Type, Union, Callable, TYPE_CHECKING
 import itertools
 from _balder.utils import inspect_method
 from _balder.fixture_manager import FixtureManager
+from _balder.fixture_execution_level import FixtureExecutionLevel
 from _balder.executor.executor_tree import ExecutorTree
 from _balder.executor.setup_executor import SetupExecutor
 from _balder.executor.scenario_executor import ScenarioExecutor
@@ -123,7 +124,8 @@ class Solver:
         :return: the fixture manager that is valid for this session
         """
         resolved_dict = {}
-        for cur_level, cur_module_fixture_dict in self._raw_fixtures.items():
+        for cur_level_as_str, cur_module_fixture_dict in self._raw_fixtures.items():
+            cur_level = FixtureExecutionLevel(cur_level_as_str)
             resolved_dict[cur_level] = {}
             for cur_fn in cur_module_fixture_dict:
                 cls, func_type = inspect_method(cur_fn)


### PR DESCRIPTION
This PR cleans up the implementation in FixtureManager. It introduces some new objects, that helps to reduce the complexity. These new objects are: 
* `FixtureExecutionLevel`: enum that describes the execution-level of a fixture
* `FixtureDefinitionScope`: enum that describes the definition-scope of a fixture
* `FixtureMetadata `: dataclass that holds all information about a fixture used in balder