### PR TITLE
docs(conf.py): use environment variable `READTHEDOCS_CANONICAL_URL` for `html_baseurl`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,6 +31,8 @@ author = 'Max Stahlschmidt'
 
 # -- General configuration ---------------------------------------------------
 
+html_context = {}
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -51,6 +53,13 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
readthedocs does not inject into conf.py file anymore