### PR TITLE
replace tuple approach implementation also internally

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -274,7 +274,7 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=6
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=15

--- a/doc/source/basics/connections.rst
+++ b/doc/source/basics/connections.rst
@@ -83,34 +83,11 @@ It is also possible that a connection requires multiple other connections (**AND
 :class:`.DnsConnection` requires a :class:`UdpConnection` **AND** a :class:`TcpConnection`, because DNS uses UDP per
 default, but it uses TCP for requests that sends data that is to much for UDP.
 
-So we can define an AND connection simply by using tuples:
+So we can define an AND connection simply with:
 
 .. code-block::
 
-    conn = DnsConnection.based_on((UdpConnection, TcpConnection))
-
-Limits of connection-relations
-------------------------------
-
-You can define **AND**/**OR** definitions in almost any possible variation, but there is one limit.
-It is not allowed to define **AND** connections inside other **AND** connections, so for example:
-
-.. code-block:: python
-
-    # ALLOWED
-    conn = SpecialConnection.based_on((AConnection, BConnection), CConnection)
-    # NOT ALLOWED
-    conn = SpecialConnection.based_on((AConnection, BConnection, (CConnection, DConnection)))
-
-The last definition is not allowed because we use an inner **AND** connection there. We can write the same logic more
-easier by refactoring the both **AND** relations:
-
-.. code-block:: python
-
-    # same like the NOT ALLOWED tree from above - BUT NOW IT IS ALLOWED
-    conn = SpecialConnection.based_on((AConnection, BConnection, CConnection, DConnection)))
-
-This limitation makes it easier to read the logic.
+    conn = DnsConnection.based_on(UdpConnection & TcpConnection)
 
 Using the base connection object
 ================================
@@ -139,7 +116,7 @@ connection:
 
 .. code-block:: python
 
-    conn = Connection.based_on(AConnection, BConnection)
+    conn = Connection.based_on(AConnection | BConnection)
 
 **A container connection always has based-on elements**.
 

--- a/doc/source/basics/features.rst
+++ b/doc/source/basics/features.rst
@@ -325,7 +325,7 @@ Basically our scenario level implementation looks like:
     from balder.connections import TcpConnection
     from .connections import SerialConnection
 
-    @balder.for_vdevice(with_vdevice='OtherVDevice', [TcpConnection, SerialConnection])
+    @balder.for_vdevice('OtherVDevice', with_connections=TcpConnection | SerialConnection)
     class SendMessengerFeature(balder.Feature):
 
         class OtherVDevice(balder.VDevice):
@@ -394,12 +394,12 @@ use the **Method-Based-Binding** decorator:
 
     class SetupSendMessengerFeature(MessengerFeature):
 
-        @balder.for_vdevice(MessengerFeature.OtherVDevice, with_connection=SerialConnection)
+        @balder.for_vdevice(MessengerFeature.OtherVDevice, with_connections=SerialConnection)
         def send(msg) -> None:
             serial = MySerial(com=..)
             ...
 
-        @balder.for_vdevice(MessengerFeature.OtherVDevice, with_connection=TcpConnection)
+        @balder.for_vdevice(MessengerFeature.OtherVDevice, with_connections=TcpConnection)
         def send(msg) -> None:
             sock = socket.socket(...)
             ...
@@ -419,7 +419,7 @@ So take a look at the following :class:`Setup`, that matches our :class:`Scenari
 
     class MySetup(balder.Setup):
 
-        @balder.connect(SlaveDevice, over_connection=balder.Connection.based_on(SerialConnection, TcpConnection))
+        @balder.connect(SlaveDevice, over_connection=SerialConnection | TcpConnection)
         class MainDevice(balder.Device):
             msg = SetupSendMessengerFeature()
 
@@ -429,7 +429,7 @@ So take a look at the following :class:`Setup`, that matches our :class:`Scenari
 This example connects the two relevant devices over a :class:`TcpConnection` with each other, because the scenario
 defines, that the devices should be connected over an TcpConnection. If the test
 now uses on of our methods ``MyMessengerFeature.send(..)``, the variation with the decorator
-``@balder.for_vdevice(..., over_connection=[TcpConnection])`` will be used.
+``@balder.for_vdevice(..., over_connection=TcpConnection)`` will be used.
 
 If one would exchange the connection with the ``SerialConnection``, Balder would select the method variation with the
 decorator ``@balder.for_vdevice(MessengerFeature.OtherVDevice, with_connection=SerialConnection)``.

--- a/doc/source/basics/scenarios.rst
+++ b/doc/source/basics/scenarios.rst
@@ -79,9 +79,9 @@ You can also define some by your own.
 In addition to define single connections, you can also select a part of the global connection tree or combine some
 connections with an OR or an AND relationship. So for example you could connect our devices and allow an Ethernet as
 well as a Serial connection, by defining
-``@balder.connect(SendDevice, over_connection=Connection.based_on(MyEthernet, MySerial))``. Of course you could also
-define, that you need both, the Serial and the Ethernet connection. This can be done by using tuples:
-``@balder.connect(SendDevice, over_connection=Connection.based_on((MyEthernet, MySerial)))``
+``@balder.connect(SendDevice, over_connection=MyEthernet | MySerial)``. Of course you could also
+define, that you need both, the Serial and the Ethernet connection. This can be done with:
+``@balder.connect(SendDevice, over_connection=MyEthernet & MySerial``
 
 In our example we only define that we want a universal :class:`Connection` between our devices ``SendDevice`` and
 ``RecvDevice``. With this the connection type doesn't matter and every connection works here.

--- a/doc/source/basics/vdevices.rst
+++ b/doc/source/basics/vdevices.rst
@@ -316,7 +316,7 @@ Let's go back to an easy scenario which only has one single vDevice:
         class Receiver(balder.Device):
             recv = RecvFeature()
 
-        @balder.connect(with_device=Receiver, over_connection=balder.Connection.based_on(SmsConnection, EMailConnection))
+        @balder.connect(with_device=Receiver, over_connection=SmsConnection | EMailConnection)
         class Sender(balder.Device):
             send = SendFeature(receiver=ScenarioSendMessage.Receiver)
 
@@ -405,11 +405,11 @@ all of that with our two features ``SendFeature`` and ``RecvFeature``:
             send_to_recv1 = SendFeature(receiver='Receiver1')
             send_to_recv2 = SendFeature(receiver='Receiver2')
 
-        @balder.connect(with_device=Sender, over_connection=balder.Connection.based_on(SmsConnection, EMailConnection))
+        @balder.connect(with_device=Sender, over_connection=SmsConnection | EMailConnection)
         class Receiver1(balder.Device):
             recv = RecvFeature()
 
-        @balder.connect(with_device=Sender, over_connection=balder.Connection.based_on(SmsConnection, EMailConnection))
+        @balder.connect(with_device=Sender, over_connection=SmsConnection | EMailConnection)
         class Receiver2(balder.Device):
             recv = RecvFeature()
 

--- a/src/_balder/cnnrelations/and_connection_relation.py
+++ b/src/_balder/cnnrelations/and_connection_relation.py
@@ -82,3 +82,16 @@ class AndConnectionRelation(BaseConnectionRelation):
             Connection.based_on(AndConnectionRelation(*cur_tuple))
             for cur_tuple in itertools.product(*singles_and_relations)
         ]
+
+    def cut_into_all_possible_subtree_branches(self) -> List[AndConnectionRelation]:
+        if not self.is_single():
+            raise ValueError('can not execute method, because relation is not single')
+
+        tuple_with_all_possibilities = (
+            tuple(cur_tuple_item.cut_into_all_possible_subtree_branches() for cur_tuple_item in self._connections))
+
+        cloned_tuple_list = []
+        for cur_tuple in list(itertools.product(*tuple_with_all_possibilities)):
+            cloned_tuple = AndConnectionRelation(*[cur_tuple_item.clone() for cur_tuple_item in cur_tuple])
+            cloned_tuple_list.append(cloned_tuple)
+        return cloned_tuple_list

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -150,3 +150,10 @@ class BaseConnectionRelation(ABC):
         """
         returns the single connections of all components of this connection relation
         """
+
+    @abstractmethod
+    def cut_into_all_possible_subtree_branches(self):
+        """
+        This method returns a list of all possible connection tree branches. A branch is a single connection, while
+        this method returns a list of all possible singles where every single connection has this connection as head.
+        """

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -32,6 +32,12 @@ class BaseConnectionRelation(ABC):
     def __len__(self):
         return len(self._connections)
 
+    def __hash__(self):
+        all_hashes = 0
+        for cur_elem in self.connections:
+            all_hashes += hash(cur_elem) + hash(self.__class__.__name__)
+        return all_hashes
+
     def __and__(
             self,
             other: Union[Connection, Type[Connection], AndConnectionRelation, OrConnectionRelation]

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import List, Union, Type, TypeVar, TYPE_CHECKING
+from typing import List, Union, Type, Dict, TypeVar, TYPE_CHECKING
 from abc import ABC, abstractmethod
 from ..utils import cnn_type_check_and_convert
 
 if TYPE_CHECKING:
     from ..connection import Connection
+    from ..device import Device
     from .and_connection_relation import AndConnectionRelation
     from .or_connection_relation import OrConnectionRelation
 
@@ -105,6 +106,16 @@ class BaseConnectionRelation(ABC):
                             f'`{relation.__class__}` | expected `{self.__class__}`)')
         for cur_elem in relation.connections:
             self.append(cur_elem)
+
+    def set_metadata_for_all_subitems(self, metadata: Union[Dict[str, Union[Device, str]], None]):
+        """
+        This method sets the metadata for all existing Connection items in this element.
+
+        :param metadata: the metadata that should be set (if the value is explicitly set to None, it removes the
+                         metadata from every item)
+        """
+        for cur_cnn in self._connections:
+            cur_cnn.set_metadata_for_all_subitems(metadata)
 
     @abstractmethod
     def get_tree_str(self) -> str:

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -117,6 +117,22 @@ class BaseConnectionRelation(ABC):
         for cur_cnn in self._connections:
             cur_cnn.set_metadata_for_all_subitems(metadata)
 
+    def get_all_used_connection_types(self) -> List[Type[Connection]]:
+        """
+        This method returns all available connection types, that are used within this connection relation.
+        """
+        from ..connection import Connection  # pylint: disable=import-outside-toplevel
+
+        result = []
+        for cur_inner_elem in self._connections:
+            if isinstance(cur_inner_elem, Connection):
+                result.append(cur_inner_elem.__class__)
+            elif isinstance(cur_inner_elem, BaseConnectionRelation):
+                result.extend(cur_inner_elem.get_all_used_connection_types())
+            else:
+                raise TypeError(f'unexpected type for inner item `{cur_inner_elem.__class__.__name__}`')
+        return list(set(result))
+
     @abstractmethod
     def get_tree_str(self) -> str:
         """

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -122,3 +122,31 @@ class BaseConnectionRelation(ABC):
         """
         returns the tree string for this part of the connection tree
         """
+
+    def is_resolved(self) -> bool:
+        """
+        returns whether this connection relation is part of a single connection
+        """
+        if len(self._connections) == 0:
+            return True
+        return min(cnn.is_resolved() for cnn in self._connections)
+
+    def get_resolved(self) -> BaseConnectionRelationT:
+        """
+        This method returns a resolved Connection Tree. This means that it convert the based_on references so that
+        every based on connection is a direct parent of the current element. It secures that there are no undefined
+        connection layers between an object and the given parent.
+        """
+        return self.__class__(*[cnn.get_resolved() for cnn in self._connections])
+
+    @abstractmethod
+    def is_single(self) -> bool:
+        """
+        returns whether this connection relation is part of a single connection
+        """
+
+    @abstractmethod
+    def get_singles(self) -> List[Connection]:
+        """
+        returns the single connections of all components of this connection relation
+        """

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -5,6 +5,7 @@ from ..utils import cnn_type_check_and_convert
 
 if TYPE_CHECKING:
     from ..connection import Connection
+    from ..connection import ConnectionMetadata
     from ..device import Device
     from .and_connection_relation import AndConnectionRelation
     from .or_connection_relation import OrConnectionRelation
@@ -68,6 +69,20 @@ class BaseConnectionRelation(ABC):
         returns the components of this connection relation
         """
         return self._connections.copy()
+
+    @property
+    def metadata(self) -> ConnectionMetadata | None:
+        """
+        returns the metadata of this connection relation
+        """
+        if not self.connections:
+            return None
+
+        # get all unique metadata objects
+        existing_metadata = list({elem.metadata for elem in self.connections if elem})
+        if len(existing_metadata) > 1:
+            raise ValueError(f'different metadata detected: `{existing_metadata}`')
+        return existing_metadata[0]
 
     @abstractmethod
     def get_simplified_relation(self) -> OrConnectionRelation:

--- a/src/_balder/cnnrelations/base_connection_relation.py
+++ b/src/_balder/cnnrelations/base_connection_relation.py
@@ -213,3 +213,21 @@ class BaseConnectionRelation(ABC):
         # check inner connection elements (if they match all in both directions)
         return (self.cnn_are_in_other(other_relation, ignore_metadata=ignore_metadata)
                 and other_relation.cnn_are_in_other(self, ignore_metadata=ignore_metadata))
+
+    @abstractmethod
+    def contained_in(self, other_conn: Union[Connection, BaseConnectionRelationT], ignore_metadata=False) -> bool:
+        """
+        This method helps to find out whether this connection relation fits within a given connection tree. A connection
+        object is a certain part of the large connection tree that Balder has at its disposal. This method checks
+        whether a possibility of this connection tree fits in one possibility of the given connection tree.
+
+        .. note::
+            The method returns true if one single connection of this object fits in another single connection that is
+            given by `other_conn`.
+
+        :param other_conn: the other connection
+
+        :param ignore_metadata: if this value is true the method ignores the metadata
+
+        :return: true if the self object is contained in the `other_conn`, otherwise false
+        """

--- a/src/_balder/cnnrelations/or_connection_relation.py
+++ b/src/_balder/cnnrelations/or_connection_relation.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import List, Union, TYPE_CHECKING
 
 from .base_connection_relation import BaseConnectionRelation
 
@@ -30,4 +30,17 @@ class OrConnectionRelation(BaseConnectionRelation):
                 result.extend(cur_inner_elem.get_simplified_relation())
             else:
                 raise TypeError(f'detect unexpected element type `{cur_inner_elem.__class__}` in inner elements')
+        return result
+
+    def is_single(self) -> bool:
+        if len(self.connections) == 0:
+            return True
+        if len(self.connections) == 1:
+            return self.connections[0].is_single()
+        return False
+
+    def get_singles(self) -> List[Connection]:
+        result = []
+        for elem in self.connections:
+            result.extend(elem.get_singles())
         return result

--- a/src/_balder/cnnrelations/or_connection_relation.py
+++ b/src/_balder/cnnrelations/or_connection_relation.py
@@ -44,3 +44,12 @@ class OrConnectionRelation(BaseConnectionRelation):
         for elem in self.connections:
             result.extend(elem.get_singles())
         return result
+
+    def cut_into_all_possible_subtree_branches(self) -> List[OrConnectionRelation]:
+        if not self.is_single():
+            raise ValueError('can not execute method, because relation is not single')
+        result = [OrConnectionRelation()]
+        if len(self.connections) == 0:
+            return result
+        result.extend(self.connections[0].cut_into_all_possible_subtree_branches())
+        return result

--- a/src/_balder/cnnrelations/or_connection_relation.py
+++ b/src/_balder/cnnrelations/or_connection_relation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import List, Union, TYPE_CHECKING
 
-from .base_connection_relation import BaseConnectionRelation
+from .base_connection_relation import BaseConnectionRelation, BaseConnectionRelationT
 
 if TYPE_CHECKING:
     from ..connection import Connection
@@ -53,3 +53,13 @@ class OrConnectionRelation(BaseConnectionRelation):
             return result
         result.extend(self.connections[0].cut_into_all_possible_subtree_branches())
         return result
+
+    def contained_in(self, other_conn: Union[Connection, BaseConnectionRelationT], ignore_metadata=False) -> bool:
+        if not self.is_resolved():
+            raise ValueError('can not execute method, because connection relation is not resolved')
+        if not other_conn.is_resolved():
+            raise ValueError('can not execute method, because other connection relation is not resolved')
+        for cur_inner_cnn in self._connections:
+            if cur_inner_cnn.contained_in(other_conn):
+                return True
+        return False

--- a/src/_balder/collector.py
+++ b/src/_balder/collector.py
@@ -27,7 +27,6 @@ from _balder.utils import get_scenario_inheritance_list_of
 
 if TYPE_CHECKING:
     from _balder.plugin_manager import PluginManager
-    ConnectionType = Union[Type[Connection], Connection, Tuple[Union[Type[Connection], Connection]]]
 
 logger = logging.getLogger(__file__)
 
@@ -45,7 +44,7 @@ class Collector:
     # with the method `rework_method_variation_decorators()`
     _possible_method_variations: Dict[
         Callable,
-        List[Tuple[Union[Type[VDevice], str], Union[ConnectionType, List[ConnectionType]]]]
+        List[Tuple[Union[Type[VDevice], str], Connection]]
     ] = {}
 
     # this static attribute will be managed by the decorator `@parametrize(..)`. It holds all functions/methods that
@@ -85,7 +84,7 @@ class Collector:
     def register_possible_method_variation(
             meth: Callable,
             vdevice: Union[Type[VDevice], str],
-            with_connections: Union[ConnectionType, List[ConnectionType]]):
+            with_connections: Connection):
         """
         allows to register a new method variation - used by decorator `@balder.for_vdevice()`
 
@@ -509,11 +508,6 @@ class Collector:
                 if name not in owner_for_vdevice.keys():
                     owner_for_vdevice[name] = {}
 
-                cur_decorator_cleaned_cnns = []
-                for cur_cnn in cur_decorator_with_connections:
-                    cur_cnn = cur_cnn() if isinstance(cur_cnn, type) and issubclass(cur_cnn, Connection) else cur_cnn
-                    cur_decorator_cleaned_cnns.append(cur_cnn)
-
                 if cur_fn in owner_for_vdevice[name].keys():
                     old_dict = owner_for_vdevice[name][cur_fn]
                     if cur_decorator_vdevice in old_dict.keys():
@@ -521,10 +515,10 @@ class Collector:
                                                        f'`{cur_decorator_vdevice}` at method `{name}` of class '
                                                        f'`{owner.__name__}` ')
 
-                    old_dict[cur_decorator_vdevice] = cur_decorator_cleaned_cnns
+                    old_dict[cur_decorator_vdevice] = cur_decorator_with_connections
                     owner_for_vdevice[name][cur_fn] = old_dict
                 else:
-                    new_dict = {cur_decorator_vdevice: cur_decorator_cleaned_cnns}
+                    new_dict = {cur_decorator_vdevice: cur_decorator_with_connections}
                     owner_for_vdevice[name][cur_fn] = new_dict
 
             def owner_wrapper(the_owner_of_this_method, the_name, wrap_fn):

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -866,7 +866,7 @@ class Connection(metaclass=ConnectionType):
 
         raise ValueError(f"the given node `{node}` is no component of the given device `{device.__qualname__}`")
 
-    def has_connection_from_to(self, start_device, end_device=None):
+    def has_connection_from_to(self, start_device, end_device=None) -> bool:
         """
         This method checks if there is a connection from ``start_device`` to ``end_device``. This will return
         true if the ``start_device`` and ``end_device`` given in this method are also the ``start_device`` and
@@ -883,18 +883,7 @@ class Connection(metaclass=ConnectionType):
 
         :return: returns true if the given direction is possible
         """
-        if end_device is None:
-
-            if self.is_bidirectional():
-                return start_device in (self.from_device, self.to_device)
-
-            return start_device == self.from_device
-
-        if self.is_bidirectional():
-            return start_device == self.from_device and end_device == self.to_device or \
-                   start_device == self.to_device and end_device == self.from_device
-
-        return start_device == self.from_device and end_device == self.to_device
+        return self.metadata.has_connection_from_to(start_device, end_device)
 
     def equal_with(self, other_conn: Connection, ignore_metadata=False) -> bool:
         """

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -464,6 +464,8 @@ class Connection(metaclass=ConnectionType):
 
     # ---------------------------------- PROTECTED METHODS -------------------------------------------------------------
 
+    # ---------------------------------- METHODS -----------------------------------------------------------------------
+
     def get_intersection_with_other_single(self, other_conn: Union[Connection, Tuple[Connection]]) \
             -> List[Connection, Tuple[Connection]]:
         """
@@ -555,8 +557,6 @@ class Connection(metaclass=ConnectionType):
 
         # only return unique objects
         return intersection_filtered
-
-    # ---------------------------------- METHODS -----------------------------------------------------------------------
 
     def clone_without_based_on_elements(self) -> Connection:
         """

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -86,10 +86,7 @@ class Connection(metaclass=ConnectionType):
         return False
 
     def __hash__(self):
-        all_hashes = hash(self.from_device) + hash(self.to_device) + hash(self.from_node_name) + \
-                     hash(self.to_node_name) + hash(str(self))
-        for cur_child in self.based_on_elements:
-            all_hashes += hash(cur_child)
+        all_hashes = hash(self.metadata) + hash(self.based_on_elements)
         return hash(all_hashes)
 
     # ---------------------------------- STATIC METHODS ----------------------------------------------------------------

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -335,26 +335,30 @@ class Connection(metaclass=ConnectionType):
         return this_instance
 
     @classmethod
-    def check_equal_connections_are_in(
-            cls, cnns_from: List[Connection], are_in_cnns_from: List[Connection], ignore_metadata: bool=False) -> bool:
+    def check_that_connections_are_equal_with(
+            cls,
+            cnns_from: List[Connection],
+            are_equal_with_cnns_of: List[Connection],
+            ignore_metadata: bool = False
+    ) -> bool:
         """
-        This method validates that the elements from the first list are contained (are equal) with one of the elements
+        This method validates that the elements from the first list are equal with one (or more) of the connection(s)
         in the second list.
 
         .. note::
-            This method only checks that every single connections from the first element is contained in the second too.
-            It does not check the other direction. If you want to validate this, you need to call this method with both
-            possibilities.
+            This method only checks that every single connections from the first element is equal with one (or more)
+            connection(s) of the other list. It does not check the other direction. If you want to validate this, you need
+            to call this method in both directions.
 
         :param cnns_from: the first list of connections
-        :param are_in_cnns_from: the second list of connection
+        :param are_equal_with_cnns_of: the second list of connection
         :param ignore_metadata: True, if the metadata of the single connections should be ignored
-        :return: True in case that every connection of the first list is equal with one in the second list, otherwise
-                 False
+        :return: True in case that every connection of the first list is equal with one (or more) connection(s) in the
+                 second list, otherwise False
         """
         for cur_cnn in cnns_from:
             found_equal = False
-            for cur_other_cnn in are_in_cnns_from:
+            for cur_other_cnn in are_equal_with_cnns_of:
                 if cur_cnn.equal_with(cur_other_cnn, ignore_metadata=ignore_metadata):
                     found_equal = True
                     break
@@ -363,28 +367,31 @@ class Connection(metaclass=ConnectionType):
         return True
 
     @classmethod
-    def check_equal_connection_tuples_are_in(
-            cls, tuples_from: List[Tuple[Connection]], are_in_tuples_from: List[Tuple[Connection]],
-            ignore_metadata: bool=False) -> bool:
+    def check_that_tuples_are_equal_with(
+            cls,
+            tuples_from: List[Tuple[Connection]],
+            are_equal_with_tuples_of: List[Tuple[Connection]],
+            ignore_metadata: bool = False
+    ) -> bool:
         """
-        This method validates that the connection tuples from the first list are contained (are equal) within the tuple
-        elements of the second list.
+        This method validates that the elements from the first list are equal with one (or more) of the elements
+        in the second list.
 
         .. note::
-            This method only checks that every single tuple from the first element is contained in the second list.
-            It does not check the other direction. If you want to validate this, you need to call this method with both
-            possibilities.
+            This method only checks that every single tuple from the first element is equal with one (or more)
+            tuple(s) of the other list. It does not check the other direction. If you want to validate this, you need
+            to call this method in both directions.
 
         :param tuples_from: the first list of connection-tuples
-        :param are_in_tuples_from: the second list of connection-tuples
+        :param are_equal_with_tuples_of: the second list of connection-tuples
         :param ignore_metadata: True, if the metadata of the single connections should be ignored
-        :return: True in case that every tuple connections of the first list is equal with one tuple in the second,
+        :return: True in case that every tuple of the first list is equal with one (or more) tuple(s) in the second,
                  otherwise False
         """
         for cur_search_tuple in tuples_from:
             found_match_for_cur_search_tuple = False
             # go through each unmatched other tuple
-            for cur_other_tuple in are_in_tuples_from:
+            for cur_other_tuple in are_equal_with_tuples_of:
                 cur_search_tuple_is_completely_in_other_tuple = True
                 for cur_search_tuple_elem in cur_search_tuple:
                     fount_it = False
@@ -910,19 +917,20 @@ class Connection(metaclass=ConnectionType):
             cur_elem for cur_elem in resolved_other.based_on_elements if isinstance(cur_elem, tuple)]
 
         # check single connection elements (if they match all in both directions)
-        if (not self.__class__.check_equal_connections_are_in(
-                cnns_from=self_based_on_elems, are_in_cnns_from=other_based_on_elems, ignore_metadata=ignore_metadata)
-                or not self.__class__.check_equal_connections_are_in(
-                    cnns_from=other_based_on_elems, are_in_cnns_from=self_based_on_elems,
+        if (not self.__class__.check_that_connections_are_equal_with(
+                cnns_from=self_based_on_elems, are_equal_with_cnns_of=other_based_on_elems,
+                ignore_metadata=ignore_metadata)
+                or not self.__class__.check_that_connections_are_equal_with(
+                    cnns_from=other_based_on_elems, are_equal_with_cnns_of=self_based_on_elems,
                     ignore_metadata=ignore_metadata)):
             return False
 
         # check tuple connection elements (if they match all in both directions)
-        if (not self.__class__.check_equal_connection_tuples_are_in(
-                tuples_from=self_based_on_tuples, are_in_tuples_from=other_based_on_tuples,
+        if (not self.__class__.check_that_tuples_are_equal_with(
+                tuples_from=self_based_on_tuples, are_equal_with_tuples_of=other_based_on_tuples,
                 ignore_metadata=ignore_metadata)
-                or not self.__class__.check_equal_connection_tuples_are_in(
-                    tuples_from=other_based_on_tuples, are_in_tuples_from=self_based_on_tuples,
+                or not self.__class__.check_that_tuples_are_equal_with(
+                    tuples_from=other_based_on_tuples, are_equal_with_tuples_of=self_based_on_tuples,
                     ignore_metadata=ignore_metadata)):
             return False
 

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -92,6 +92,8 @@ class Connection(metaclass=ConnectionType):
             all_hashes += hash(cur_child)
         return hash(all_hashes)
 
+    # ---------------------------------- STATIC METHODS ----------------------------------------------------------------
+
     @staticmethod
     def __cut_conn_from_only_parent_to_child(elem: Connection) -> List[Connection]:
         """
@@ -247,8 +249,6 @@ class Connection(metaclass=ConnectionType):
                             next_loop = True
                             break
         return result
-
-    # ---------------------------------- STATIC METHODS ----------------------------------------------------------------
 
     # ---------------------------------- CLASS METHODS ----------------------------------------------------------------
 

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -92,37 +92,6 @@ class Connection(metaclass=ConnectionType):
             all_hashes += hash(cur_child)
         return hash(all_hashes)
 
-    def clone_without_based_on_elements(self) -> Connection:
-        """
-        This method returns a copied version of this element, while all `_based_on_connections` are removed (the copied
-        element has an empty list here).
-
-        :return: a python copied object of this item
-        """
-        self_copy = copy.copy(self)
-        self_copy._based_on_connections = []  # pylint: disable=protected-access
-        return self_copy
-
-    def clone(self) -> Connection:
-        """
-        This method returns an exact clone of this connection. For this clone every inner connection object will be
-        newly instantiated, but all internal references (like the devices and so on) will not be copied (objects are the
-        same for this object and the clone). The method will make a normal copy for every connection object in the
-        `_based_on_elements` list.
-        """
-        self_copy = self.clone_without_based_on_elements()
-
-        for cur_based_on in self._based_on_connections:
-            if isinstance(cur_based_on, tuple):
-                cloned_tuple = tuple([cur_tuple_element.clone() for cur_tuple_element in cur_based_on])
-                self_copy.append_to_based_on(cloned_tuple)
-            elif isinstance(cur_based_on, Connection):
-                cloned_cur_based_on = cur_based_on.clone()
-                self_copy.append_to_based_on(cloned_cur_based_on)
-            else:
-                raise TypeError('based on element is not from valid type')
-        return self_copy
-
     @staticmethod
     def __cut_conn_from_only_parent_to_child(elem: Connection) -> List[Connection]:
         """
@@ -588,6 +557,37 @@ class Connection(metaclass=ConnectionType):
         return intersection_filtered
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
+
+    def clone_without_based_on_elements(self) -> Connection:
+        """
+        This method returns a copied version of this element, while all `_based_on_connections` are removed (the copied
+        element has an empty list here).
+
+        :return: a python copied object of this item
+        """
+        self_copy = copy.copy(self)
+        self_copy._based_on_connections = []  # pylint: disable=protected-access
+        return self_copy
+
+    def clone(self) -> Connection:
+        """
+        This method returns an exact clone of this connection. For this clone every inner connection object will be
+        newly instantiated, but all internal references (like the devices and so on) will not be copied (objects are the
+        same for this object and the clone). The method will make a normal copy for every connection object in the
+        `_based_on_elements` list.
+        """
+        self_copy = self.clone_without_based_on_elements()
+
+        for cur_based_on in self._based_on_connections:
+            if isinstance(cur_based_on, tuple):
+                cloned_tuple = tuple([cur_tuple_element.clone() for cur_tuple_element in cur_based_on])
+                self_copy.append_to_based_on(cloned_tuple)
+            elif isinstance(cur_based_on, Connection):
+                cloned_cur_based_on = cur_based_on.clone()
+                self_copy.append_to_based_on(cloned_cur_based_on)
+            else:
+                raise TypeError('based on element is not from valid type')
+        return self_copy
 
     def cut_into_all_possible_subtrees(self) -> List[Union[Connection, Tuple[Connection]]]:
         """

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -843,28 +843,7 @@ class Connection(metaclass=ConnectionType):
         :param node: the node name of the device itself (only required if the connection starts and ends with the same
                      device)
         """
-        if device not in (self.from_device, self.to_device):
-            raise ValueError(f"the given device `{device.__qualname__}` is no component of this connection")
-        if node is None:
-            # check that the from_device and to_device are not the same
-            if self.from_device == self.to_device:
-                raise ValueError("the connection is a inner-device connection (start and end is the same device) - you "
-                                 "have to provide the `node` string too")
-            if device == self.from_device:
-                return self.to_device, self.to_node_name
-
-            return self.from_device, self.from_node_name
-
-        if node not in (self.from_node_name, self.to_node_name):
-            raise ValueError(f"the given node `{node}` is no component of this connection")
-
-        if device == self.from_device and node == self.from_node_name:
-            return self.to_device, self.to_node_name
-
-        if device == self.to_device and node == self.to_node_name:
-            return self.from_device, self.from_node_name
-
-        raise ValueError(f"the given node `{node}` is no component of the given device `{device.__qualname__}`")
+        return self.metadata.get_conn_partner_of(device, node)
 
     def has_connection_from_to(self, start_device, end_device=None) -> bool:
         """

--- a/src/_balder/connection.py
+++ b/src/_balder/connection.py
@@ -223,33 +223,6 @@ class Connection(metaclass=ConnectionType):
         # now get the variations and add them to our results
         return list(itertools.product(*singles_tuple))
 
-    @staticmethod
-    def cleanup_connection_list(full_list: List[Union[Connection, Tuple[Connection]]]) \
-            -> List[Union[Connection, Tuple[Connection]]]:
-        """
-        This method cleanup a connection list while removing items that are direct duplicates and by removing duplicates
-        that are fully contained_in other items.
-
-        :param full_list: the full list of connections and tuples of connections that should be cleaned-up
-
-        :returns: returns the cleaned up list
-        """
-        result = full_list.copy()
-        next_loop = True
-        while not next_loop:
-            next_loop = False
-            for cur_elem in result:
-                all_other_elems = [cur_item for cur_item in result if cur_item != cur_elem]
-                if isinstance(cur_elem, Connection):
-                    for cur_other_elem in all_other_elems:
-                        # check if it contained in or the same
-                        if cur_elem.contained_in(cur_other_elem, ignore_metadata=True):
-                            # we can remove it from result list
-                            result.remove(cur_elem)
-                            next_loop = True
-                            break
-        return result
-
     # ---------------------------------- CLASS METHODS ----------------------------------------------------------------
 
     @classmethod

--- a/src/_balder/connection_metadata.py
+++ b/src/_balder/connection_metadata.py
@@ -39,6 +39,11 @@ class ConnectionMetadata:
     def __eq__(self, other: ConnectionMetadata):
         return self.equal_with(other)
 
+    def __hash__(self):
+        all_hashes = hash(self._from_device) + hash(self._to_device) + hash(self._from_device_node_name) + \
+                     hash(self._to_device_node_name) + hash(self._bidirectional)
+        return hash(all_hashes)
+
     def __compare_with(self, other: ConnectionMetadata, allow_single_unidirectional_for_both_directions: bool) -> bool:
         """
         This method checks, if the metadata of this object is the metadata of the other object.

--- a/src/_balder/connection_metadata.py
+++ b/src/_balder/connection_metadata.py
@@ -110,6 +110,36 @@ class ConnectionMetadata:
                             f"`to_device_node_name` - should be a string value")
         self._to_device_node_name = to_device_node_name
 
+    def has_connection_from_to(self, start_device, end_device=None) -> bool:
+        """
+        This method checks if there is a connection from ``start_device`` to ``end_device``. This will return
+        true if the ``start_device`` and ``end_device`` given in this method are also the ``start_device`` and
+        ``end_device`` mentioned in this connection object. If this is a bidirectional connection, ``start_device`` and
+        ``end_device`` can switch places.
+
+
+        :param start_device: the device for which the method should check whether it is a communication partner (for
+                             non-bidirectional connection, this has to be the start device)
+
+        :param end_device: the other device for which the method should check whether it is a communication partner (for
+                           non-bidirectional connection, this has to be the end device - this is optional if only the
+                           start device should be checked)
+
+        :return: returns true if the given direction is possible
+        """
+        if end_device is None:
+
+            if self.bidirectional:
+                return start_device in (self.from_device, self.to_device)
+
+            return start_device == self.from_device
+
+        if self.bidirectional:
+            return start_device == self.from_device and end_device == self.to_device or \
+                   start_device == self.to_device and end_device == self.from_device
+
+        return start_device == self.from_device and end_device == self.to_device
+
     def equal_with(self, other: ConnectionMetadata) -> bool:
         """
         This method returns true if the metadata of the current connection is equal with the metadata of the given

--- a/src/_balder/connection_metadata.py
+++ b/src/_balder/connection_metadata.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+from typing import Union, Type
+from .device import Device
+
+
+class ConnectionMetadata:
+    """
+    Describes the metadata of a connection.
+    """
+
+    def __init__(
+            self,
+            from_device: Union[Type[Device], None] = None,
+            to_device: Union[Type[Device], None] = None,
+            from_device_node_name: Union[str, None] = None,
+            to_device_node_name: Union[str, None] = None,
+            bidirectional: bool = True,
+    ):
+
+        self._from_device = None
+        self._from_device_node_name = None
+        self.set_from(from_device, from_device_node_name)
+
+        self._to_device = None
+        self._to_device_node_name = None
+        self.set_to(to_device, to_device_node_name)
+
+        if not ((from_device is None and to_device is None and from_device_node_name is None
+                 and to_device_node_name is None) or (
+                from_device is not None and to_device is not None and from_device_node_name is not None and
+                to_device_node_name is not None)):
+            raise ValueError(
+                "you have to provide all or none of the following items: `from_device`, `from_device_node_name`, "
+                "`to_device` or `to_device_node_name`")
+
+        # describes if the connection is uni or bidirectional
+        self._bidirectional = bidirectional
+
+    def __eq__(self, other: ConnectionMetadata):
+        return self.equal_with(other)
+
+    def __compare_with(self, other: ConnectionMetadata, allow_single_unidirectional_for_both_directions: bool) -> bool:
+        """
+        This method checks, if the metadata of this object is the metadata of the other object.
+
+        The method returns true in the following situations:
+        * both connections are bidirectional / the FROM and TO elements (device and node name) are the same
+        * both connections are bidirectional / the FROM is the TO and the TO is the FROM
+        * both connections are unidirectional and have the same from and to elements
+
+        If the parameter `allow_single_unidirectional_for_both_directions` is True, it additionally checks the following
+        situations:
+        * one is unidirectional / the other is bidirectional / the FROM and TO elements are the same
+        * one is unidirectional / the other is bidirectional / the FROM is the TO and the TO is the FROM
+        """
+        def check_same() -> bool:
+            return (self.from_device == other.from_device and self.from_node_name == other.from_node_name and
+                    self.to_device == other.to_device and self.to_node_name == other.to_node_name)
+
+        def check_twisted() -> bool:
+            return (self.from_device == other.to_device and self.from_node_name == other.to_node_name and
+                    self.to_device == other.from_device and self.to_node_name == other.from_node_name)
+
+        # CHECK: both connections are bidirectional / the FROM and TO elements (device and node name) are the same
+        # CHECK: both connections are bidirectional / the FROM is the TO and the TO is the FROM
+        if self.bidirectional and other.bidirectional:
+            return check_same() or check_twisted()
+        # CHECK: both connections are unidirectional and have the same from and to elements
+        if not self.bidirectional and not other.bidirectional:
+            return check_same()
+
+        if allow_single_unidirectional_for_both_directions:
+            # CHECK: one is unidirectional / the other is bidirectional / the FROM and TO elements are the same
+            # CHECK: one is unidirectional / the other is bidirectional / the FROM is the TO and the TO is the FROM
+            if self.bidirectional and not other.bidirectional or not self.bidirectional and other.bidirectional:
+                return check_same() or check_twisted()
+        return False
+
+    def set_from(self, from_device: Union[Type[Device], None], from_device_node_name: Union[str, None] = None):
+        """
+        This method sets the FROM device and node for this connection.
+
+        :param from_device: The FROM device of this connection.
+        :param from_device_node_name: The FROM node of this connection (if it should be set, otherwise None).
+        """
+        if from_device is not None and isinstance(from_device, type) and not issubclass(from_device, Device):
+            raise TypeError(f"detect illegal argument element {str(from_device)} for given attribute "
+                            f"`from_device` - should be a subclasses of `balder.Device`")
+        self._from_device = from_device
+
+        if from_device_node_name is not None and not isinstance(from_device_node_name, str):
+            raise TypeError(f"detect illegal argument type {type(from_device_node_name)} for given attribute "
+                            f"`from_device_node_name` - should be a string value")
+        self._from_device_node_name = from_device_node_name
+
+    def set_to(self, to_device: Union[Type[Device], None], to_device_node_name: Union[str, None] = None):
+        """
+        This method sets the TO device and node of this connection.
+
+        :param to_device: The TO device of this connection.
+        :param to_device_node_name: The TO node of this connection (if it should be set, otherwise None).
+        """
+        if to_device is not None and isinstance(to_device, type) and not issubclass(to_device, Device):
+            raise TypeError(f"detect illegal argument element {str(to_device)} for given attribute "
+                            f"`to_device` - should be a subclasses of `balder.Device`")
+        self._to_device = to_device
+
+        if to_device_node_name is not None and not isinstance(to_device_node_name, str):
+            raise TypeError(f"detect illegal argument type {type(to_device_node_name)} for given attribute "
+                            f"`to_device_node_name` - should be a string value")
+        self._to_device_node_name = to_device_node_name
+
+    def equal_with(self, other: ConnectionMetadata) -> bool:
+        """
+        This method returns true if the metadata of the current connection is equal with the metadata of the given
+        connection.
+
+        The method returns true in the following situations:
+        * both connections are bidirectional and the from and to elements (device and node name) are the same
+        * both connections are unidirectional and have the same from and to elements
+        * both connections are bidirectional and the from is the to and the to is the from
+
+        :return: true if the metadata of the current connection is contained in the metadata of the given one
+        """
+        return self.__compare_with(other, allow_single_unidirectional_for_both_directions=False)
+
+    def contained_in(self, other: ConnectionMetadata) -> bool:
+        """
+        This method returns true if the metadata of the current connection is contained in the given one.
+
+        The method returns true in the following situations:
+        * both connections are bidirectional and the from and to elements (device and node name) are the same
+        * both connections are unidirectional and have the same from and to elements
+        * both connections are bidirectional and the from is the to and the to is the from
+        * one connection is unidirectional and the other is bidirectional and the from and to elements are the same
+        * one connection is unidirectional and the other is bidirectional and the from is the to and the to is the from
+
+        :return: true if the metadata of the current connection is contained in the metadata of the given one
+        """
+        return self.__compare_with(other, allow_single_unidirectional_for_both_directions=True)
+
+    @property
+    def from_device(self):
+        """device from which the connection starts"""
+        return self._from_device
+
+    @property
+    def to_device(self):
+        """device at which the connection ends"""
+        return self._to_device
+
+    @property
+    def from_node_name(self):
+        """the name of the node in the `Device` from which the connection starts"""
+        return self._from_device_node_name
+
+    @property
+    def to_node_name(self):
+        """the name of the node in the `Device` at which the connection ends"""
+        return self._to_device_node_name
+
+    @property
+    def bidirectional(self) -> bool:
+        """
+        returns true if the connection is bidirectional (can go in both directions) otherwise false
+        """
+        return self._bidirectional

--- a/src/_balder/controllers/device_controller.py
+++ b/src/_balder/controllers/device_controller.py
@@ -342,16 +342,16 @@ class DeviceController(BaseDeviceController, ABC):
                 if cur_conn.to_device in all_inner_classes_of_outer.keys():
                     meta = cur_conn.metadata
 
-                    meta["to_device"] = all_inner_classes_of_outer[cur_conn.to_device]
-                    if meta["to_device_node_name"] is None:
-                        # no unique node was given -> create one
-                        meta["to_device_node_name"] = \
-                            DeviceController.get_for(meta["to_device"]).get_new_empty_auto_node()
+                    to_device = all_inner_classes_of_outer[cur_conn.to_device]
+                    # if there was given no unique node -> create one
+                    to_device_node_name = DeviceController.get_for(to_device).get_new_empty_auto_node() \
+                        if meta.to_node_name is None else meta.to_node_name
 
-                    # first reset whole metadata
-                    cur_conn.metadata = {}
-                    # now set metadata
-                    cur_conn.metadata = meta
+                    meta.set_to(
+                        to_device=to_device,
+                        to_device_node_name=to_device_node_name)
+
+                    cur_conn.set_metadata_for_all_subitems(meta)
                 else:
                     raise DeviceResolvingException(
                         f"cannot resolve the str for the given device class `{cur_conn.to_device}` for "

--- a/src/_balder/controllers/device_controller.py
+++ b/src/_balder/controllers/device_controller.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, List, Type, Tuple, Union, TYPE_CHECKING
+from typing import Dict, List, Type, Union, TYPE_CHECKING
 
 import sys
 import logging
@@ -257,7 +257,7 @@ class DeviceController(BaseDeviceController, ABC):
     #     for cur_gateway in self._gateways:
     #         cur_gateway.validate_given_node_names()
 
-    def get_node_types(self) -> Dict[str, List[Connection, Tuple[Connection]]]:
+    def get_node_types(self) -> Dict[str, List[Connection | None]]:
         """
         This method returns a dictionary with the node name as key and a connection class as value. This class
         describes the common connection sub-tree, that all incoming and outgoing connections of the related device have

--- a/src/_balder/controllers/feature_controller.py
+++ b/src/_balder/controllers/feature_controller.py
@@ -590,30 +590,20 @@ class FeatureController(Controller):
             parent_vdevice_feature = relevant_parent_class_controller.get_outer_class()
             if parent_vdevice_feature not in to_checking_parent_features:
                 to_checking_parent_features.append(parent_vdevice_feature)
-            parent_vdevice_cnn = \
+            parent_vdevice_cnns = \
                 FeatureController.get_for(
                     parent_vdevice_feature).get_abs_class_based_for_vdevice()[relevant_parent_class]
+            parent_vdevice_cnn = Connection.based_on(OrConnectionRelation(*parent_vdevice_cnns))
             # check if VDevice connection elements are all contained in the parent connection
             for cur_element in cur_vdevice_cls_cnn:
-                if isinstance(cur_element, tuple):
-                    if not Connection.check_if_tuple_contained_in_connection(
-                            cur_element, Connection.based_on(OrConnectionRelation(*parent_vdevice_cnn))):
-                        raise VDeviceResolvingError(
-                            f"the VDevice `{cur_vdevice.__name__}` is a child of the VDevice "
-                            f"`{relevant_parent_class.__name__}`, which doesn't implements the connection of "
-                            f"the child - the connection tuple `("
-                            f"{', '.join([cur_tuple_item.get_tree_str() for cur_tuple_item in cur_element])})´"
-                            f" is not contained in the connection-tree of the parent VDevice")
-                else:
-                    if not cur_element.contained_in(
-                            Connection.based_on(OrConnectionRelation(*parent_vdevice_cnn)), ignore_metadata=True):
-                        raise VDeviceResolvingError(
-                            f"the VDevice `{cur_vdevice.__name__}` is a child of the VDevice "
-                            f"`{relevant_parent_class.__name__}`, which doesn't implements the connection of "
-                            f"the child - the connection element `{cur_element.get_tree_str()})´ is not "
-                            f"contained in the connection-tree of the parent VDevice")
+                if not cur_element.contained_in(parent_vdevice_cnn, ignore_metadata=True):
+                    raise VDeviceResolvingError(
+                        f"the VDevice `{cur_vdevice.__name__}` is a child of the VDevice "
+                        f"`{relevant_parent_class.__name__}`, which doesn't implements the connection of "
+                        f"the child - the connection element `{cur_element.get_tree_str()})´ is not "
+                        f"contained in the connection-tree of the parent VDevice")
 
-        # check all features where we have found parent VDevices as inner-classes to check next inheritance levels
+        # validate inheritance levels for all features with parent VDevices as inner-classes
         for cur_feature in to_checking_parent_features:
             FeatureController.get_for(cur_feature).validate_inherited_class_based_vdevice_cnn_subset()
 

--- a/src/_balder/controllers/normal_scenario_setup_controller.py
+++ b/src/_balder/controllers/normal_scenario_setup_controller.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from _balder.setup import Setup
 from _balder.device import Device
 from _balder.scenario import Scenario
+from _balder.connection_metadata import ConnectionMetadata
 from _balder.controllers.controller import Controller
 from _balder.controllers.device_controller import DeviceController
 from _balder.controllers.vdevice_controller import VDeviceController
@@ -374,11 +375,10 @@ class NormalScenarioSetupController(Controller, ABC):
                         all_devices[all_devices_as_strings.index(cur_parent_cnn.from_device.__name__)]
                     related_to_device = all_devices[all_devices_as_strings.index(cur_parent_cnn.to_device.__name__)]
                     new_cnn = cur_parent_cnn.clone()
-                    new_cnn.set_metadata_for_all_subitems(None)
-                    new_cnn.set_metadata_for_all_subitems(
-                        {"from_device": related_from_device, "to_device": related_to_device,
-                         "from_device_node_name": cur_parent_cnn.from_node_name,
-                         "to_device_node_name": cur_parent_cnn.to_node_name})
+                    new_cnn.set_metadata_for_all_subitems(ConnectionMetadata(
+                        from_device=related_from_device, from_device_node_name=cur_parent_cnn.from_node_name,
+                        to_device=related_to_device, to_device_node_name=cur_parent_cnn.to_node_name)
+                    )
                     all_relevant_cnns.append(new_cnn)
 
                 # throw warning (but only if this scenario/setup has minimum one of the parent classes has inner

--- a/src/_balder/controllers/scenario_controller.py
+++ b/src/_balder/controllers/scenario_controller.py
@@ -216,8 +216,8 @@ class ScenarioController(NormalScenarioSetupController):
 
                 # now check if one or more single of the classbased connection are CONTAINED IN the possible
                 # parallel connection (only if there exists more than one parallel)
-                feature_cnn = Connection.based_on(OrConnectionRelation(*FeatureController.get_for(
-                        cur_feature.__class__).get_abs_class_based_for_vdevice()[mapped_vdevice]))
+                feature_cnn = FeatureController.get_for(
+                    cur_feature.__class__).get_abs_class_based_for_vdevice()[mapped_vdevice]
 
                 # search node names that is the relevant connection
                 relevant_cnns: List[Connection] = []
@@ -339,10 +339,9 @@ class ScenarioController(NormalScenarioSetupController):
                     continue
 
                 # now try to reduce the scenario connections according to the requirements of the feature class
-                cur_feature_class_based_for_vdevice = \
+                cur_feature_cnn = \
                     FeatureController.get_for(
                         cur_feature.__class__).get_abs_class_based_for_vdevice()[mapped_vdevice]
-                cur_feature_cnn = Connection.based_on(OrConnectionRelation(*cur_feature_class_based_for_vdevice))
 
                 device_cnn_singles = get_single_cnns_between_device_for_feature(
                     from_device=cur_from_device, to_device=mapped_device, relevant_feature_cnn=cur_feature_cnn)

--- a/src/_balder/controllers/setup_controller.py
+++ b/src/_balder/controllers/setup_controller.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 from typing import Type, Dict, Union, TYPE_CHECKING
 
 import logging
-from _balder.cnnrelations import OrConnectionRelation
 from _balder.setup import Setup
-from _balder.connection import Connection
 from _balder.exceptions import IllegalVDeviceMappingError, MultiInheritanceError
 from _balder.controllers.feature_controller import FeatureController
 from _balder.controllers.device_controller import DeviceController
@@ -114,8 +112,7 @@ class SetupController(NormalScenarioSetupController):
                     continue
 
                 # there exists a class based requirement for this vDevice
-                class_based_cnn = Connection.based_on(
-                    OrConnectionRelation(*feature_class_based_for_vdevice[mapped_vdevice]))
+                class_based_cnn = feature_class_based_for_vdevice[mapped_vdevice]
                 # search relevant connection
                 cur_device_controller = DeviceController.get_for(cur_device)
                 for _, cur_cnn_list in cur_device_controller.get_all_absolute_connections().items():

--- a/src/_balder/decorator_connect.py
+++ b/src/_balder/decorator_connect.py
@@ -96,8 +96,8 @@ def connect(
                 cur_cnn_instance = over_connection()
             elif isinstance(over_connection, (AndConnectionRelation, OrConnectionRelation)):
                 over_connection = Connection.based_on(over_connection)
-            cur_cnn_instance.set_devices(from_device=decorated_cls, to_device=with_device)
-            cur_cnn_instance.update_node_names(from_device_node_name=self_node_name, to_device_node_name=dest_node_name)
+            cur_cnn_instance.metadata.set_from(from_device=decorated_cls, from_device_node_name=self_node_name)
+            cur_cnn_instance.metadata.set_to(to_device=with_device, to_device_node_name=dest_node_name)
 
             decorated_cls_device_controller.add_new_raw_connection(cur_cnn_instance)
             return decorated_cls

--- a/src/_balder/executor/testcase_executor.py
+++ b/src/_balder/executor/testcase_executor.py
@@ -12,7 +12,6 @@ from _balder.testresult import ResultState, TestcaseResult
 from _balder.utils import inspect_method
 
 if TYPE_CHECKING:
-    from _balder.executor.unresolved_parametrized_testcase_executor import UnresolvedParametrizedTestcaseExecutor
     from _balder.executor.variation_executor import VariationExecutor
     from _balder.fixture_manager import FixtureManager
     from _balder.scenario import Scenario

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -3,7 +3,7 @@ from typing import Type, Union, List, Dict, Tuple, TYPE_CHECKING
 
 import inspect
 import logging
-from _balder.cnnrelations import AndConnectionRelation, OrConnectionRelation
+from _balder.cnnrelations import OrConnectionRelation
 from _balder.device import Device
 from _balder.connection import Connection
 from _balder.fixture_execution_level import FixtureExecutionLevel
@@ -878,10 +878,7 @@ class VariationExecutor(BasicExecutableExecutor):
                         if cur_cnn.has_connection_from_to(start_device=setup_device, end_device=mapped_setup_device):
                             if cur_cnn.__class__ == Connection:
                                 # add the children
-                                for cur_inner_cnn in cur_cnn.based_on_elements:
-                                    if isinstance(cur_inner_cnn, tuple):
-                                        cur_inner_cnn = AndConnectionRelation(*cur_inner_cnn)
-                                    relevant_abs_conn.append(cur_inner_cnn)
+                                relevant_abs_conn.extend(cur_cnn.based_on_elements.connections)
                             else:
                                 relevant_abs_conn.append(cur_cnn)
                     if len(relevant_abs_conn) is None:

--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -727,7 +727,7 @@ class VariationExecutor(BasicExecutableExecutor):
 
                 # get relevant class based connections for the current feature on setup level (this is really be used
                 # here)
-                feature_cnns = \
+                feature_cnn = \
                     FeatureController.get_for(
                         cur_setup_feature.__class__).get_abs_class_based_for_vdevice()[cur_setup_feature_vdevice]
                 # connection that are relevant for this feature
@@ -739,19 +739,18 @@ class VariationExecutor(BasicExecutableExecutor):
                     # we have parallel possibilities -> determine the selected one (only one is allowed to fit)
                     for cur_relevant_cnn in relevant_cnns:
                         for cur_relevant_single_cnn in cur_relevant_cnn.get_singles():
-                            for cur_feature_cnn in feature_cnns:
-                                for cur_feature_single_cnn in cur_feature_cnn.get_singles():
-                                    if cur_feature_single_cnn.contained_in(cur_relevant_single_cnn):
-                                        if relevant_device_cnn is not None:
-                                            raise UnclearAssignableFeatureConnectionError(
-                                                f"the devices {cur_scenario_device.__name__} and "
-                                                f"{cur_mapped_scenario_device.__name__} have multiple parallel "
-                                                f"connections - the device `{cur_scenario_device.__name__}` uses a "
-                                                f"feature `{cur_scenario_feature.__class__.__name__}` that matches "
-                                                f"with the device `{cur_mapped_scenario_device.__name__}`, but it is "
-                                                f"not clear which of the parallel connection could be used"
-                                            )
-                                        relevant_device_cnn = cur_relevant_cnn
+                            for cur_feature_single_cnn in feature_cnn.get_singles():
+                                if cur_feature_single_cnn.contained_in(cur_relevant_single_cnn):
+                                    if relevant_device_cnn is not None:
+                                        raise UnclearAssignableFeatureConnectionError(
+                                            f"the devices {cur_scenario_device.__name__} and "
+                                            f"{cur_mapped_scenario_device.__name__} have multiple parallel "
+                                            f"connections - the device `{cur_scenario_device.__name__}` uses a "
+                                            f"feature `{cur_scenario_feature.__class__.__name__}` that matches "
+                                            f"with the device `{cur_mapped_scenario_device.__name__}`, but it is "
+                                            f"not clear which of the parallel connection could be used"
+                                        )
+                                    relevant_device_cnn = cur_relevant_cnn
                 elif len(relevant_cnns) == 1:
                     relevant_device_cnn = relevant_cnns[0]
                 if relevant_device_cnn is None:
@@ -762,9 +761,8 @@ class VariationExecutor(BasicExecutableExecutor):
                 # connection
                 new_cleaned_singles = OrConnectionRelation()
                 for cur_old_cnn_single in relevant_device_cnn.get_singles():
-                    for cur_feature_cnn in feature_cnns:
-                        if cur_feature_cnn.contained_in(cur_old_cnn_single, ignore_metadata=True):
-                            new_cleaned_singles.append(cur_old_cnn_single)
+                    if feature_cnn.contained_in(cur_old_cnn_single, ignore_metadata=True):
+                        new_cleaned_singles.append(cur_old_cnn_single)
 
                 new_cnn_to_replace = Connection.based_on(new_cleaned_singles)
                 new_cnn_to_replace.set_metadata_for_all_subitems(new_cleaned_singles[0].metadata)

--- a/src/_balder/routing_path.py
+++ b/src/_balder/routing_path.py
@@ -167,7 +167,7 @@ class RoutingPath:
     # ---------------------------------- PROPERTIES --------------------------------------------------------------------
 
     @property
-    def elements(self) -> List[Connection, NodeGateway]:
+    def elements(self) -> List[Union[Connection, NodeGateway]]:
         """returns all elements that belongs to this routing path"""
         return self._routing_elems
 

--- a/src/_balder/routing_path.py
+++ b/src/_balder/routing_path.py
@@ -324,8 +324,7 @@ class RoutingPath:
                 # todo
                 pass
         # set metadata based on this routing
-        virtual_connection.set_devices(from_device=self.start_device, to_device=self.end_device)
-        virtual_connection.update_node_names(from_device_node_name=self.start_node_name,
-                                             to_device_node_name=self.end_node_name)
+        virtual_connection.metadata.set_from(from_device=self.start_device, from_device_node_name=self.start_node_name)
+        virtual_connection.metadata.set_to(to_device=self.end_device, to_device_node_name=self.end_node_name)
 
         return virtual_connection

--- a/src/_balder/solver.py
+++ b/src/_balder/solver.py
@@ -117,7 +117,7 @@ class Solver:
 
     # ---------------------------------- METHODS -----------------------------------------------------------------------
 
-    def get_initial_mapping(self) -> List[Tuple[Type[Setup], Type[Scenario], Dict[Device, Device]]]:
+    def get_initial_mapping(self) -> List[Tuple[Type[Setup], Type[Scenario], Dict[Type[Device], Type[Device]]]]:
         """
         This method creates the initial amount of data for `self._mapping`. Only those elements are returned where the
         :meth:`Setup` class has more or the same amount of :meth:`Device`'s than the :meth:`Scenario` class.


### PR DESCRIPTION
This PR replaces the tuple/list implementation for OR/AND connection relations completely with the new And-/OrConnectionRelation objects.

Please note the breaking changes described in https://github.com/balder-dev/balder/pull/107. 

This PR adds the new `|`/`&` approach also to the decorator `@balder.for_vdevice()`.