### PR TITLE
fix(controllers): use `inspect.getmembers()` on types, not on instances

### DIFF
--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -868,7 +868,7 @@ class VariationExecutor(BasicExecutableExecutor):
                 method_var_selection = {}
 
                 for cur_method_name, _ in inspect.getmembers(
-                        cur_setup_feature, lambda o: inspect.isfunction(o) or inspect.ismethod(o)):
+                        cur_setup_feature.__class__, lambda o: inspect.isfunction(o) or inspect.ismethod(o)):
 
                     if cur_method_name not in method_var_data_of_feature.keys():
                         # ignore if there was no method-variation registration for the current method


### PR DESCRIPTION
This results in an issue when collecting feature properties that use other methods that are decorated with `@balder.for_vdevice()`. `inspect.getmembers()` executes properties, when the item is an object. 

We do not need to call this on methods, it is okay to use the type to get all methods that belong to that feature instance.