### PR TITLE
fix: VDevice not in Variation issue

### DIFF
--- a/src/_balder/executor/variation_executor.py
+++ b/src/_balder/executor/variation_executor.py
@@ -744,10 +744,9 @@ class VariationExecutor(BasicExecutableExecutor):
                 )
 
                 if vdev_mappings_of_setup_feature[0].device not in self.base_device_mapping.values():
-                    raise NotApplicableVariationException(
-                        f'the mapped setup device `{vdev_mappings_of_setup_feature[0].device.__qualname__}` which is '
-                        f'mapped to the VDevice `{vdev_mappings_of_setup_feature[0].vdevice.__qualname__}` is no part '
-                        f'of this variation')
+                    # ignore this device if it is no part of the mapping (assigned VDev, that does not have an
+                    # mapped scenario device)
+                    continue
 
                 cur_mapped_scenario_device = self.get_scenario_device_for(vdev_mappings_of_setup_feature[0].device)
 

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/env/lib/features.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/env/lib/features.py
@@ -13,6 +13,12 @@ class AddCalculateFeature(balder.Feature):
         raise NotImplementedError("has to be implemented in subclass")
 
 
+class CalculatorHelperFeature(balder.Feature):
+
+    def get_help_with(self, number):
+        return number
+
+
 class ProvidesANumberFeature(balder.Feature):
     the_number = 0
 

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/env/setups/features_setup.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/env/setups/features_setup.py
@@ -1,4 +1,5 @@
-from ..lib.features import AddCalculateFeature, ProvidesANumberFeature
+import balder
+from ..lib.features import AddCalculateFeature, ProvidesANumberFeature, CalculatorHelperFeature
 from ..lib.utils import SharedObj
 
 
@@ -12,6 +13,9 @@ class PyAddProvideANumber(ProvidesANumberFeature):
 
 
 class PyAddCalculate(AddCalculateFeature):
+
+    class Helper(balder.VDevice):
+        helper = CalculatorHelperFeature()
 
     def get_numbers(self):
         self.all_numbers = SharedObj.shared_mem_list

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/env/setups/setup_pythonadd.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/env/setups/setup_pythonadd.py
@@ -1,24 +1,25 @@
 import balder
 from ..lib.connections import MySimplySharedMemoryConnection
 from ..lib.utils import SharedObj
+from ..lib.features import CalculatorHelperFeature
 from .features_setup import PyAddCalculate, PyAddProvideANumber
 
 
 class SetupPythonAdd(balder.Setup):
 
-    class Calculator1(balder.Device):
-        calc = PyAddCalculate()
+    class HelperDevice(balder.Device):
+        """this device is no part of the variation, but used as vdevice"""
+        helper = CalculatorHelperFeature()
 
-    class Calculator2(balder.Device):
-        calc = PyAddCalculate()
+    @balder.connect(HelperDevice, over_connection=balder.Connection)
+    class Calculator1(balder.Device):
+        calc = PyAddCalculate(Helper='HelperDevice')
 
     @balder.connect(Calculator1, over_connection=MySimplySharedMemoryConnection)
-    @balder.connect(Calculator2, over_connection=MySimplySharedMemoryConnection)
     class NumberProvider1(balder.Device):
         n = PyAddProvideANumber(Calculator="Calculator1")
 
     @balder.connect(Calculator1, over_connection=MySimplySharedMemoryConnection)
-    @balder.connect(Calculator2, over_connection=MySimplySharedMemoryConnection)
     class NumberProvider2(balder.Device):
         n = PyAddProvideANumber(Calculator="Calculator1")
 

--- a/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
+++ b/tests/vdevice/test_1_vdevice_which_is_no_part_of_a_variation/test_1_vdevice_which_is_no_part_of_a_variation.py
@@ -8,14 +8,8 @@ def test_1_vdevice_which_is_no_part_of_a_variation(balder_working_dir):
     """
     This testcase is a modified version of the calculator environment.
 
-    The setup defines two calculator devices `Calculator1` and `Calculator2` that theoretically could map to the
-    scenario device `Calculator`. Normally both of these setup devices `Calculator1` and `Calculator2` should map.
-
-    However, since we have a VDevice mapping on setup level only to the `Calculator1` device, balder should not allow
-    the second variation, at which the `Calculator2` would be mapped to the scenario device `Calculator`, because it
-    cannot be used as VDevice.
-
-    The test secures that only the mapped `Calculator1` is a valid variation.
+    The setup defines two an additional helper devices `HelperDevice` that is never a part of the variation (does not
+    have a mapped scenario-device). It is expected, that the variation is executed and the VDevice is mapped.
     """
     proc = Process(target=processed, args=(balder_working_dir, ))
     proc.start()
@@ -36,9 +30,3 @@ def processed(env_dir):
     scenario_executors = session.executor_tree.get_setup_executors()[0].get_scenario_executors()
     assert len(scenario_executors) == 1
     assert len(scenario_executors[0].get_variation_executors()) == 2
-    for cur_variation_executor in scenario_executors[0].get_variation_executors():
-        all_setup_devices = [cur_device.__name__ for cur_device in cur_variation_executor.base_device_mapping.values()]
-        assert "Calculator1" in all_setup_devices, \
-            "can not find the expected `Calculator` setup device in mapped-devices"
-        assert "Calculator2" not in all_setup_devices, \
-            "`Calculator2` should not be contained in mapped-devices"


### PR DESCRIPTION
This PR fixes an issue that variations will be discarded, if they have a mapped VDevices that is not part of this variation. This is a common use case and should be possible to run.